### PR TITLE
Upgrade MCP SDK to 1.27.1, migrate to registerTool API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^4.0.7",
-        "@modelcontextprotocol/sdk": "^1.0.4",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "commander": "^12.1.0",
         "dotenv": "^16.4.5",
         "graphql": "^16.11.0",
@@ -35,7 +35,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@apollo/client": "^4.0.7",
-    "@modelcontextprotocol/sdk": "^1.0.4",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "graphql": "^16.11.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,83 +1,22 @@
 #!/usr/bin/env node
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { validateToolArgs } from "./utils/validation.js";
-import {
-  searchAssetsTool,
-  executeSearchAssets,
-  SearchAssetsArgsSchema,
-} from "./tools/butlr-search-assets.js";
-import {
-  getAssetDetailsTool,
-  executeGetAssetDetails,
-  GetAssetDetailsArgsSchema,
-} from "./tools/butlr-get-asset-details.js";
-import {
-  hardwareSnapshotTool,
-  executeHardwareSnapshot,
-  HardwareSnapshotArgsSchema,
-} from "./tools/butlr-hardware-snapshot.js";
+import { registerSearchAssets } from "./tools/butlr-search-assets.js";
+import { registerGetAssetDetails } from "./tools/butlr-get-asset-details.js";
+import { registerHardwareSnapshot } from "./tools/butlr-hardware-snapshot.js";
 
 const SERVER_NAME = "butlr-mcp-server";
 const SERVER_VERSION = "0.1.0";
 
-const server = new Server(
-  { name: SERVER_NAME, version: SERVER_VERSION },
-  { capabilities: { tools: {} } }
-);
-
-const allTools = [searchAssetsTool, getAssetDetailsTool, hardwareSnapshotTool];
-
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return { tools: allTools };
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
 });
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-
-  try {
-    let result: unknown;
-
-    switch (name) {
-      case "butlr_search_assets": {
-        const validated = validateToolArgs(SearchAssetsArgsSchema, args);
-        result = await executeSearchAssets(validated);
-        break;
-      }
-      case "butlr_get_asset_details": {
-        const validated = validateToolArgs(GetAssetDetailsArgsSchema, args);
-        result = await executeGetAssetDetails(validated);
-        break;
-      }
-      case "butlr_hardware_snapshot": {
-        const validated = validateToolArgs(HardwareSnapshotArgsSchema, args);
-        result = await executeHardwareSnapshot(validated);
-        break;
-      }
-      default:
-        throw new Error(`Unknown tool: ${name}`);
-    }
-
-    return {
-      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-    };
-  } catch (error) {
-    if (process.env.DEBUG) {
-      console.error(`[${SERVER_NAME}] Error executing ${name}:`, error);
-    }
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    };
-  }
-});
+// Register all tools
+registerSearchAssets(server);
+registerGetAssetDetails(server);
+registerHardwareSnapshot(server);
 
 async function main() {
   const transport = new StdioServerTransport();
@@ -86,7 +25,6 @@ async function main() {
   if (process.env.DEBUG === "butlr-mcp" || process.env.DEBUG === "*") {
     console.error(`[${SERVER_NAME}] Server started on stdio transport`);
     console.error(`[${SERVER_NAME}] Version: ${SERVER_VERSION}`);
-    console.error(`[${SERVER_NAME}] Available tools: ${allTools.length}`);
   }
 }
 

--- a/src/tools/butlr-get-asset-details.ts
+++ b/src/tools/butlr-get-asset-details.ts
@@ -1,3 +1,4 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { apolloClient } from "../clients/graphql-client.js";
 import { gql } from "@apollo/client";
 import { z } from "zod";
@@ -467,4 +468,44 @@ export async function executeGetAssetDetails(args: GetAssetDetailsArgs) {
     },
     timestamp: new Date().toISOString(),
   };
+}
+
+/**
+ * Register butlr_get_asset_details with an McpServer instance
+ */
+export function registerGetAssetDetails(server: McpServer): void {
+  server.registerTool(
+    "butlr_get_asset_details",
+    {
+      title: "Get Butlr Asset Details",
+      description: getAssetDetailsTool.description,
+      inputSchema: {
+        ids: z
+          .array(z.string().min(1))
+          .min(1, "ids must contain at least 1 asset ID")
+          .max(50, "ids cannot exceed 50 assets")
+          .describe("Asset IDs to fetch (e.g., ['room_123', 'floor_456'])"),
+        include_children: z.boolean().default(true).describe("Include child assets"),
+        include_devices: z.boolean().default(false).describe("Include sensors and hives"),
+        include_parent_context: z
+          .boolean()
+          .default(true)
+          .describe("Include parent names for context"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      const validated = GetAssetDetailsArgsSchema.parse(args);
+      const result = await executeGetAssetDetails(validated);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }
+  );
 }

--- a/src/tools/butlr-hardware-snapshot.ts
+++ b/src/tools/butlr-hardware-snapshot.ts
@@ -1,3 +1,4 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { apolloClient } from "../clients/graphql-client.js";
 import { gql } from "@apollo/client";
 import { z } from "zod";
@@ -729,4 +730,60 @@ export async function executeHardwareSnapshot(args: HardwareSnapshotArgs) {
   }
 
   return response;
+}
+
+/**
+ * Register butlr_hardware_snapshot with an McpServer instance
+ */
+export function registerHardwareSnapshot(server: McpServer): void {
+  server.registerTool(
+    "butlr_hardware_snapshot",
+    {
+      title: "Butlr Hardware Health Snapshot",
+      description: hardwareSnapshotTool.description,
+      inputSchema: {
+        scope_type: z
+          .enum(["org", "site", "building", "floor"])
+          .default("org")
+          .describe("Scope of the health check"),
+        scope_id: z.string().min(1).optional().describe("Required if scope_type is not 'org'"),
+        include_battery_details: z
+          .boolean()
+          .default(false)
+          .describe("Include list of sensors needing battery service"),
+        battery_status_filter: z
+          .enum(["critical", "due_soon", "healthy", "all"])
+          .default("all")
+          .describe("Filter battery details by status"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .default(20)
+          .describe("Max devices in battery_details list"),
+        offline_devices_limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .default(20)
+          .describe("Max offline devices to show"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false, // Real-time data changes between calls
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      const validated = HardwareSnapshotArgsSchema.parse(args);
+      const result = await executeHardwareSnapshot(validated);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        structuredContent: result as Record<string, unknown>,
+      };
+    }
+  );
 }

--- a/src/tools/butlr-search-assets.ts
+++ b/src/tools/butlr-search-assets.ts
@@ -1,3 +1,4 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { apolloClient } from "../clients/graphql-client.js";
 import { z } from "zod";
 import { GET_FULL_TOPOLOGY } from "../clients/queries/topology.js";
@@ -284,4 +285,51 @@ export async function executeSearchAssets(args: SearchAssetsArgs) {
     searched_assets: searchableAssets.length,
     timestamp: new Date().toISOString(),
   };
+}
+
+/**
+ * Register butlr_search_assets with an McpServer instance
+ */
+export function registerSearchAssets(server: McpServer): void {
+  server.registerTool(
+    "butlr_search_assets",
+    {
+      title: "Search Butlr Assets",
+      description: searchAssetsTool.description,
+      inputSchema: {
+        query: z
+          .string()
+          .min(1, "query cannot be empty")
+          .max(500, "query too long (max: 500 chars)")
+          .describe("Search term to match against asset names"),
+        asset_types: z
+          .array(z.enum(VALID_ASSET_TYPES))
+          .min(1)
+          .max(VALID_ASSET_TYPES.length)
+          .optional()
+          .describe("Optional: Filter to specific asset types"),
+        max_results: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .default(20)
+          .describe("Maximum number of results to return"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      const validated = SearchAssetsArgsSchema.parse(args);
+      const result = await executeSearchAssets(validated);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }
+  );
 }


### PR DESCRIPTION
## Summary
Upgrade from MCP SDK 1.0.4 to 1.27.1 and migrate from deprecated `Server` class to modern `McpServer` with `registerTool()`.

### What Changed

**SDK Upgrade** (`@modelcontextprotocol/sdk` 1.0.4 → 1.27.1)
- Unlocks `registerTool()`, `structuredContent`, `outputSchema`, `title`, and content annotations

**Server Architecture** (`src/index.ts`)
- Replace `Server` + `setRequestHandler(ListToolsRequestSchema)` + manual switch dispatch
- With `McpServer` + `registerTool()` — each tool self-registers via `register*()` function
- No more centralized tool routing — tools are decoupled from index.ts

**Per-Tool Changes** (all 3 tools)
- Add `register*()` export function that calls `server.registerTool()`
- Pass Zod schemas directly as `inputSchema` (SDK converts to JSON Schema)
- Add `title` field (new spec feature: human-readable display name)
- Add `structuredContent` in responses (new spec feature: typed JSON alongside text)
- Fix `hardware_snapshot` `idempotentHint: false` (real-time data changes between calls)
- Existing hand-written JSON Schema `inputSchema` objects preserved for now (will be removed in follow-up once verified the SDK-generated schemas are equivalent)

### What's NOT Changed
- All existing Zod validation schemas (`.strict()`, `.refine()`) preserved
- All `execute*()` functions unchanged
- All test assertions unchanged

## Test Plan
- [x] `npm run typecheck` passes
- [x] 230 tests pass (9 suites)
- [x] Pre-commit hooks validated