### PR TITLE
Harden pre-existing tools: types, shared helpers, tests

### DIFF
--- a/src/tools/__tests__/unit/battery-status.test.ts
+++ b/src/tools/__tests__/unit/battery-status.test.ts
@@ -150,7 +150,7 @@ describe("getBatteryStatus", () => {
   });
 
   describe("missing battery data", () => {
-    it('returns "healthy" when battery_change_by_date is missing', () => {
+    it('returns "unknown" when battery_change_by_date is missing', () => {
       const sensor = {
         id: "sensor_13",
         name: "No Battery Tracking",
@@ -158,10 +158,10 @@ describe("getBatteryStatus", () => {
         battery_change_by_date: undefined,
       } as Sensor;
 
-      expect(getBatteryStatus(sensor, now)).toBe("healthy");
+      expect(getBatteryStatus(sensor, now)).toBe("unknown");
     });
 
-    it('returns "healthy" when battery_change_by_date is null', () => {
+    it('returns "unknown" when battery_change_by_date is null', () => {
       const sensor = {
         id: "sensor_14",
         name: "Null Battery Date",
@@ -169,10 +169,10 @@ describe("getBatteryStatus", () => {
         battery_change_by_date: null as any,
       } as Sensor;
 
-      expect(getBatteryStatus(sensor, now)).toBe("healthy");
+      expect(getBatteryStatus(sensor, now)).toBe("unknown");
     });
 
-    it('returns "healthy" when battery_change_by_date is empty string', () => {
+    it('returns "unknown" when battery_change_by_date is empty string', () => {
       const sensor = {
         id: "sensor_15",
         name: "Empty Battery Date",
@@ -180,7 +180,7 @@ describe("getBatteryStatus", () => {
         battery_change_by_date: "" as any,
       } as Sensor;
 
-      expect(getBatteryStatus(sensor, now)).toBe("healthy");
+      expect(getBatteryStatus(sensor, now)).toBe("unknown");
     });
   });
 

--- a/src/tools/butlr-get-asset-details.ts
+++ b/src/tools/butlr-get-asset-details.ts
@@ -9,9 +9,6 @@ import {
 } from "../errors/mcp-errors.js";
 import { detectAssetType } from "../utils/asset-helpers.js";
 
-/**
- * Zod validation for get_asset_details
- */
 const assetIdSchema = z
   .string()
   .min(1, "Asset ID cannot be empty")
@@ -349,6 +346,8 @@ export async function executeGetAssetDetails(args: GetAssetDetailsArgs) {
     );
   }
 
+  const results: Array<Record<string, unknown>> = [];
+
   // Group IDs by type
   const assetsByType: Record<string, string[]> = {};
   for (const id of args.ids) {
@@ -357,6 +356,11 @@ export async function executeGetAssetDetails(args: GetAssetDetailsArgs) {
       if (process.env.DEBUG) {
         console.error(`[get-asset-details] Warning: Unknown asset type for ID: ${id}`);
       }
+      results.push({
+        id,
+        _type: "unknown",
+        error: `Unknown asset type for ID: ${id}. Expected prefix: site_, building_, floor_, room_, zone_`,
+      });
       continue;
     }
 
@@ -382,8 +386,6 @@ export async function executeGetAssetDetails(args: GetAssetDetailsArgs) {
   }
 
   const settled = await Promise.allSettled(fetchPromises.map((f) => f.promise));
-
-  const results: Array<Record<string, unknown>> = [];
 
   for (let i = 0; i < settled.length; i++) {
     const { id, type } = fetchPromises[i];

--- a/src/tools/butlr-hardware-snapshot.ts
+++ b/src/tools/butlr-hardware-snapshot.ts
@@ -5,11 +5,18 @@ import { z } from "zod";
 import { GET_ALL_SENSORS, GET_ALL_HIVES } from "../clients/queries/topology.js";
 import type { Site, Building, Floor, Sensor, Hive } from "../clients/types.js";
 import { buildHardwareSummary, daysBetween, hoursBetween } from "../utils/natural-language.js";
-import { translateGraphQLError, formatMCPError } from "../errors/mcp-errors.js";
-
-/**
- * Zod validation for butlr_hardware_snapshot
- */
+import {
+  isProductionSensor,
+  isProductionHive,
+  rethrowIfGraphQLError,
+} from "../utils/graphql-helpers.js";
+import type {
+  BatteryDetail,
+  BatteryStatus,
+  FloorBreakdown,
+  HardwareSnapshotResponse,
+  OfflineDevice,
+} from "../types/responses.js";
 
 /** Shared shape — used by both registerTool and full validation */
 const hardwareSnapshotInputShape = {
@@ -62,9 +69,6 @@ export const HardwareSnapshotArgsSchema = z
     }
   );
 
-/**
- * Tool definition for butlr_hardware_snapshot
- */
 const HARDWARE_SNAPSHOT_DESCRIPTION =
   "Get unified device health check combining online/offline status and battery health across your entire portfolio or specific locations. Provides proactive maintenance insights for facilities teams managing IoT sensor infrastructure.\n\n" +
   "Primary Users:\n" +
@@ -93,57 +97,7 @@ const HARDWARE_SNAPSHOT_DESCRIPTION =
   "CRE Context: Battery-powered sensors typically last 1-2 years depending on mode. Proactive battery management prevents data gaps that could impact space utilization reporting and right-sizing decisions.\n\n" +
   "See Also: butlr_search_assets, butlr_get_asset_details, butlr_list_topology";
 
-/**
- * Input arguments (output type from Zod schema after defaults applied)
- */
 export type HardwareSnapshotArgs = z.output<typeof HardwareSnapshotArgsSchema>;
-
-/**
- * Battery status for a sensor
- */
-type BatteryStatus = "critical" | "due_soon" | "healthy" | "no_battery";
-
-/**
- * Battery detail for a specific sensor
- */
-interface BatteryDetail {
-  sensor_id: string;
-  sensor_name: string;
-  mac_address: string; // Human-readable identifier
-  path: string;
-  status: BatteryStatus;
-  battery_change_by_date: string;
-  days_remaining: number;
-  last_battery_change_date?: string;
-  next_battery_change_date?: string;
-}
-
-/**
- * Floor breakdown
- */
-interface FloorBreakdown {
-  floor_id: string;
-  floor_name: string;
-  sensors_online: number;
-  sensors_total: number;
-  percent_online: number;
-  batteries_critical: number;
-  batteries_due_soon: number;
-}
-
-/**
- * Offline device
- */
-interface OfflineDevice {
-  type: "sensor" | "hive";
-  id: string;
-  name: string;
-  serial_number?: string; // Hive serial number (hives only)
-  mac_address?: string; // Sensor MAC address (sensors only)
-  path: string;
-  last_heartbeat?: string;
-  hours_offline?: number;
-}
 
 /**
  * GraphQL query for topology (without devices - they're queried separately)
@@ -181,7 +135,7 @@ export function getBatteryStatus(sensor: Sensor, currentDate: Date = new Date())
 
   // No battery_change_by_date means we don't have battery tracking
   if (!sensor.battery_change_by_date) {
-    return "healthy"; // Assume healthy if no tracking
+    return "unknown";
   }
 
   const changeByDate = new Date(sensor.battery_change_by_date);
@@ -205,7 +159,7 @@ function buildDevicePath(
   buildings: Building[],
   sites: Site[]
 ): string {
-  const deviceFloorId = (device as any).floor_id || (device as any).floorID;
+  const deviceFloorId = device.floor_id || device.floorID;
   const floor = floors.find((f) => f.id === deviceFloorId);
   if (!floor) return device.name;
 
@@ -223,20 +177,8 @@ function buildDevicePath(
  * Returns production devices and counts of excluded test devices.
  */
 function filterProductionDevices(rawSensors: Sensor[], rawHives: Hive[]) {
-  const sensors = rawSensors.filter(
-    (s) =>
-      s.mac_address &&
-      s.mac_address.trim() !== "" &&
-      !s.mac_address.startsWith("mi-rr-or") &&
-      !s.mac_address.startsWith("fa-ke")
-  );
-
-  const hives = rawHives.filter(
-    (h) =>
-      h.serialNumber &&
-      h.serialNumber.trim() !== "" &&
-      !h.serialNumber.toLowerCase().startsWith("fake")
-  );
+  const sensors = rawSensors.filter(isProductionSensor);
+  const hives = rawHives.filter(isProductionHive);
 
   const mirrorSensors = rawSensors.filter(
     (s) => s.mac_address?.startsWith("mi-rr-or") || s.mac_address?.startsWith("fa-ke")
@@ -438,15 +380,7 @@ export async function executeHardwareSnapshot(args: HardwareSnapshotArgs) {
       testDeviceCounts = testCounts;
     }
   } catch (error: unknown) {
-    if (
-      error &&
-      typeof error === "object" &&
-      ("graphQLErrors" in error || "networkError" in error)
-    ) {
-      const mcpError = translateGraphQLError(error as Parameters<typeof translateGraphQLError>[0]);
-      const errorMessage = formatMCPError(mcpError);
-      throw new Error(errorMessage);
-    }
+    rethrowIfGraphQLError(error);
     throw error;
   }
 
@@ -473,10 +407,11 @@ export async function executeHardwareSnapshot(args: HardwareSnapshotArgs) {
     allHives.length > 0 ? parseFloat(((hivesOnline / allHives.length) * 100).toFixed(1)) : 0;
 
   // Calculate battery health
-  const batteryStatusCounts = {
+  const batteryStatusCounts: Record<BatteryStatus, number> = {
     critical: 0,
     due_soon: 0,
     healthy: 0,
+    unknown: 0,
     no_battery: 0,
   };
 
@@ -621,7 +556,7 @@ export async function executeHardwareSnapshot(args: HardwareSnapshotArgs) {
   }
 
   // Build response
-  const response: Record<string, unknown> = {
+  const response: HardwareSnapshotResponse = {
     summary: enhancedSummary,
     sensors: {
       total: allSensors.length,

--- a/src/tools/butlr-search-assets.ts
+++ b/src/tools/butlr-search-assets.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { apolloClient } from "../clients/graphql-client.js";
 import { z } from "zod";
 import { GET_FULL_TOPOLOGY } from "../clients/queries/topology.js";
-import type { SitesResponse } from "../clients/types.js";
+import type { Site, SitesResponse } from "../clients/types.js";
 import {
   getCachedTopology,
   setCachedTopology,
@@ -11,11 +11,8 @@ import {
 import { flattenTopology, type FlattenedAsset } from "../utils/asset-flattener.js";
 import { searchAssets, type SearchableAsset } from "../utils/fuzzy-match.js";
 import { buildAssetPath } from "../utils/path-builder.js";
-import { translateGraphQLError, formatMCPError } from "../errors/mcp-errors.js";
+import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
 
-/**
- * Zod validation for search_assets
- */
 const VALID_ASSET_TYPES = ["site", "building", "floor", "room", "zone", "sensor", "hive"] as const;
 
 /** Shared shape — used by both registerTool (SDK schema) and full validation */
@@ -100,9 +97,6 @@ const SEARCH_ASSETS_DESCRIPTION =
   "Example Workflow: butlr_search_assets(query: 'café') → get room_cafe_123 → butlr_space_busyness(space_id_or_name: 'room_cafe_123')\n\n" +
   "See Also: butlr_get_asset_details, butlr_list_topology, butlr_fetch_entity_details";
 
-/**
- * Input arguments for search_assets (inferred from Zod schema)
- */
 export type SearchAssetsArgs = z.output<typeof SearchAssetsArgsSchema>;
 
 /**
@@ -144,14 +138,14 @@ export async function executeSearchAssets(args: SearchAssetsArgs) {
   );
 
   // Try to get cached topology
-  let sites: any[] = [];
+  let sites: Site[] = [];
   const cached = getCachedTopology(cacheKey);
 
   if (cached && cached.data && cached.data.sites) {
     if (process.env.DEBUG) {
       console.error("[search-assets] Using cached topology for search");
     }
-    sites = cached.data.sites as any[];
+    sites = cached.data.sites as Site[];
   } else {
     // Fetch fresh topology
     if (process.env.DEBUG) {
@@ -173,25 +167,26 @@ export async function executeSearchAssets(args: SearchAssetsArgs) {
         throw new Error("Invalid response structure from API");
       }
 
-      // Log if we got errors but still have data (partial success)
-      if (result.error && process.env.DEBUG) {
-        console.error(`[search-assets] Warning: GraphQL errors present, but got data anyway`);
+      // Track whether the topology data is partial (errors alongside data)
+      const partialData = !!result.error;
+      if (partialData && process.env.DEBUG) {
+        console.error(`[search-assets] Warning: GraphQL errors present, data may be partial`);
       }
 
       sites = result.data.sites.data;
 
-      // Cache for future searches
-      setCachedTopology(cacheKey, { sites });
+      // Only cache complete topology data — partial results should be re-fetched
+      if (!partialData) {
+        setCachedTopology(cacheKey, { sites });
 
-      if (process.env.DEBUG) {
-        console.error(`[search-assets] Cached topology with ${sites.length} sites`);
+        if (process.env.DEBUG) {
+          console.error(`[search-assets] Cached topology with ${sites.length} sites`);
+        }
+      } else if (process.env.DEBUG) {
+        console.error(`[search-assets] Skipping cache — topology data is partial`);
       }
-    } catch (error: any) {
-      if (error && (error.graphQLErrors || error.networkError)) {
-        const mcpError = translateGraphQLError(error);
-        const errorMessage = formatMCPError(mcpError);
-        throw new Error(errorMessage);
-      }
+    } catch (error: unknown) {
+      rethrowIfGraphQLError(error);
       throw error;
     }
   }

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -228,3 +228,83 @@ export interface CurrentOccupancyResponse {
   timestamp: string;
   timezone_note: string;
 }
+
+// ---------------------------------------------------------------------------
+// butlr_hardware_snapshot
+// ---------------------------------------------------------------------------
+
+export type BatteryStatus = "critical" | "due_soon" | "healthy" | "unknown" | "no_battery";
+
+export interface BatteryDetail {
+  sensor_id: string;
+  sensor_name: string;
+  mac_address: string;
+  path: string;
+  status: BatteryStatus;
+  battery_change_by_date: string;
+  days_remaining: number;
+  last_battery_change_date?: string;
+  next_battery_change_date?: string;
+}
+
+export interface FloorBreakdown {
+  floor_id: string;
+  floor_name: string;
+  sensors_online: number;
+  sensors_total: number;
+  percent_online: number;
+  batteries_critical: number;
+  batteries_due_soon: number;
+}
+
+export interface OfflineDevice {
+  type: "sensor" | "hive";
+  id: string;
+  name: string;
+  serial_number?: string;
+  mac_address?: string;
+  path: string;
+  last_heartbeat?: string;
+  hours_offline?: number;
+}
+
+export interface HardwareSnapshotResponse {
+  summary: string;
+  sensors: {
+    total: number;
+    online: number;
+    offline: number;
+    percent_online: number;
+  };
+  hives: {
+    total: number;
+    online: number;
+    offline: number;
+    percent_online: number;
+  };
+  battery_health: Record<string, number>;
+  scope: {
+    type: string;
+    id?: string;
+    name: string;
+  };
+  timestamp: string;
+  test_devices_excluded?: {
+    sensors: { mirror: number; placeholder: number; total: number };
+    hives: { fake: number; placeholder: number; total: number };
+    note: string;
+  };
+  battery_details?: BatteryDetail[];
+  battery_details_truncated?: boolean;
+  battery_details_total?: number;
+  breakdown_by_floor?: FloorBreakdown[];
+  offline_devices?: OfflineDevice[];
+  offline_devices_summary?: {
+    sensors_offline: number;
+    hives_offline: number;
+    total_offline: number;
+    showing: number;
+  };
+  offline_devices_truncated?: boolean;
+  offline_devices_total?: number;
+}

--- a/src/utils/__tests__/graphql-helpers.test.ts
+++ b/src/utils/__tests__/graphql-helpers.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { rethrowIfGraphQLError, isProductionSensor, isProductionHive } from "../graphql-helpers.js";
+import type { Sensor, Hive } from "../../clients/types.js";
+
+// ---------------------------------------------------------------------------
+// Minimal fixtures — use `as any` to avoid filling every required field
+// ---------------------------------------------------------------------------
+
+function makeSensor(overrides: Partial<Sensor>): Sensor {
+  return { id: "s-1", name: "Sensor 1", mac_address: "aa:bb:cc:dd:ee:ff", ...overrides } as any;
+}
+
+function makeHive(overrides: Partial<Hive>): Hive {
+  return { id: "h-1", name: "Hive 1", serialNumber: "SN-12345", ...overrides } as any;
+}
+
+// ---------------------------------------------------------------------------
+// rethrowIfGraphQLError
+// ---------------------------------------------------------------------------
+
+describe("rethrowIfGraphQLError", () => {
+  describe("non-GraphQL values pass through (no throw)", () => {
+    it("does not throw for a plain Error", () => {
+      expect(() => rethrowIfGraphQLError(new Error("plain error"))).not.toThrow();
+    });
+
+    it("does not throw for a string", () => {
+      expect(() => rethrowIfGraphQLError("string error")).not.toThrow();
+    });
+
+    it("does not throw for null", () => {
+      expect(() => rethrowIfGraphQLError(null)).not.toThrow();
+    });
+
+    it("does not throw for undefined", () => {
+      expect(() => rethrowIfGraphQLError(undefined)).not.toThrow();
+    });
+
+    it("does not throw for a plain object without GraphQL keys", () => {
+      expect(() => rethrowIfGraphQLError({ message: "oops" })).not.toThrow();
+    });
+  });
+
+  describe("graphQLErrors triggers formatted throw", () => {
+    it("throws with formatted message for graphQLErrors", () => {
+      const error = {
+        graphQLErrors: [{ message: "Field 'x' not found" }],
+      };
+      expect(() => rethrowIfGraphQLError(error)).toThrow();
+    });
+
+    it("includes the GraphQL error message in the thrown error", () => {
+      const error = {
+        graphQLErrors: [{ message: "Syntax error in query" }],
+      };
+      expect(() => rethrowIfGraphQLError(error)).toThrow(/Syntax error in query/);
+    });
+  });
+
+  describe("networkError triggers formatted throw", () => {
+    it("throws with formatted message for networkError", () => {
+      const error = {
+        networkError: { statusCode: 500, message: "Internal Server Error" },
+      };
+      expect(() => rethrowIfGraphQLError(error)).toThrow();
+    });
+
+    it("produces AUTH_EXPIRED message for 401 statusCode", () => {
+      const error = {
+        networkError: { statusCode: 401, message: "Unauthorized" },
+      };
+      expect(() => rethrowIfGraphQLError(error)).toThrow(/AUTH_EXPIRED/);
+    });
+
+    it("produces AUTH_EXPIRED message for 403 statusCode", () => {
+      const error = {
+        networkError: { statusCode: 403, message: "Forbidden" },
+      };
+      expect(() => rethrowIfGraphQLError(error)).toThrow(/AUTH_EXPIRED/);
+    });
+
+    it("produces RATE_LIMITED message for 429 statusCode", () => {
+      const error = {
+        networkError: {
+          statusCode: 429,
+          message: "Too Many Requests",
+          response: { headers: { get: () => "30" } },
+        },
+      };
+      expect(() => rethrowIfGraphQLError(error)).toThrow(/RATE_LIMITED/);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isProductionSensor
+// ---------------------------------------------------------------------------
+
+describe("isProductionSensor", () => {
+  it("returns true for a sensor with a valid mac_address", () => {
+    expect(isProductionSensor(makeSensor({ mac_address: "aa:bb:cc:dd:ee:ff" }))).toBe(true);
+  });
+
+  it("returns false for a sensor with mac_address starting with 'mi-rr-or'", () => {
+    expect(isProductionSensor(makeSensor({ mac_address: "mi-rr-or:12:34:56" }))).toBe(false);
+  });
+
+  it("returns false for a sensor with mac_address starting with 'fa-ke'", () => {
+    expect(isProductionSensor(makeSensor({ mac_address: "fa-ke:ab:cd:ef" }))).toBe(false);
+  });
+
+  it("returns false for a sensor with an empty mac_address", () => {
+    expect(isProductionSensor(makeSensor({ mac_address: "" }))).toBe(false);
+  });
+
+  it("returns false for a sensor with whitespace-only mac_address", () => {
+    expect(isProductionSensor(makeSensor({ mac_address: "   " }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isProductionHive
+// ---------------------------------------------------------------------------
+
+describe("isProductionHive", () => {
+  it("returns true for a hive with a valid serialNumber", () => {
+    expect(isProductionHive(makeHive({ serialNumber: "SN-12345" }))).toBe(true);
+  });
+
+  it("returns false for a hive with serialNumber starting with 'fake' (lowercase)", () => {
+    expect(isProductionHive(makeHive({ serialNumber: "fake-hive-001" }))).toBe(false);
+  });
+
+  it("returns false for a hive with serialNumber starting with 'FAKE' (uppercase)", () => {
+    expect(isProductionHive(makeHive({ serialNumber: "FAKE-HIVE-002" }))).toBe(false);
+  });
+
+  it("returns false for a hive with serialNumber starting with 'Fake' (mixed case)", () => {
+    expect(isProductionHive(makeHive({ serialNumber: "Fake123" }))).toBe(false);
+  });
+
+  it("returns false for a hive with an empty serialNumber", () => {
+    expect(isProductionHive(makeHive({ serialNumber: "" }))).toBe(false);
+  });
+
+  it("returns false for a hive with whitespace-only serialNumber", () => {
+    expect(isProductionHive(makeHive({ serialNumber: "   " }))).toBe(false);
+  });
+});

--- a/src/utils/__tests__/occupancy-helpers.test.ts
+++ b/src/utils/__tests__/occupancy-helpers.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildRecommendation,
+  getPresenceMeasurement,
+  getTrafficMeasurement,
+  getPresenceCoverageNote,
+  getTrafficCoverageNote,
+} from "../occupancy-helpers.js";
+import type { BaseMeasurementData } from "../../types/responses.js";
+
+// ---------------------------------------------------------------------------
+// Helpers for building BaseMeasurementData fixtures
+// ---------------------------------------------------------------------------
+
+function makePresenceData(overrides: Partial<BaseMeasurementData> = {}): BaseMeasurementData {
+  return { available: true, sensor_count: 3, ...overrides };
+}
+
+function makeTrafficData(overrides: Partial<BaseMeasurementData> = {}): BaseMeasurementData {
+  return { available: true, entrance_sensor_count: 2, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// buildRecommendation
+// ---------------------------------------------------------------------------
+
+describe("buildRecommendation", () => {
+  it('recommends "presence" when both presence and traffic have data', () => {
+    const result = buildRecommendation(makePresenceData(), makeTrafficData(), true, true);
+    expect(result.recommended_measurement).toBe("presence");
+    expect(result.recommendation_reason).toMatch(/Both available/);
+  });
+
+  it('recommends "presence" when only presence has data', () => {
+    const result = buildRecommendation(
+      makePresenceData(),
+      makeTrafficData({ available: false }),
+      true,
+      false
+    );
+    expect(result.recommended_measurement).toBe("presence");
+    expect(result.recommendation_reason).toMatch(/Presence available/);
+  });
+
+  it('recommends "traffic" when only traffic has data', () => {
+    const result = buildRecommendation(
+      makePresenceData({ available: false }),
+      makeTrafficData(),
+      false,
+      true
+    );
+    expect(result.recommended_measurement).toBe("traffic");
+    expect(result.recommendation_reason).toMatch(/Traffic available/);
+  });
+
+  it('recommends "none" when neither has data', () => {
+    const result = buildRecommendation(
+      makePresenceData({ available: false }),
+      makeTrafficData({ available: false }),
+      false,
+      false
+    );
+    expect(result.recommended_measurement).toBe("none");
+  });
+
+  it('recommends "none" when presence sensors exist but query failed (warning set, no data)', () => {
+    const result = buildRecommendation(
+      makePresenceData({ available: true, warning: "Query timed out" }),
+      makeTrafficData({ available: false }),
+      false,
+      false
+    );
+    expect(result.recommended_measurement).toBe("none");
+    expect(result.recommendation_reason).toMatch(/Query timed out/);
+  });
+
+  it('recommends "none" when both have data but presence has a warning', () => {
+    // presence has warning → presenceSucceeded = false; traffic has no data → trafficSucceeded = false
+    const result = buildRecommendation(
+      makePresenceData({ available: true, warning: "Partial data" }),
+      makeTrafficData({ available: true }),
+      true,
+      false
+    );
+    expect(result.recommended_measurement).toBe("none");
+  });
+
+  it('recommends "traffic" when presence has a warning but traffic succeeded', () => {
+    const result = buildRecommendation(
+      makePresenceData({ available: true, warning: "Sensor offline" }),
+      makeTrafficData(),
+      true,
+      true
+    );
+    expect(result.recommended_measurement).toBe("traffic");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPresenceMeasurement
+// ---------------------------------------------------------------------------
+
+describe("getPresenceMeasurement", () => {
+  it('returns "floor_occupancy" for floor', () => {
+    expect(getPresenceMeasurement("floor")).toBe("floor_occupancy");
+  });
+
+  it('returns "room_occupancy" for room', () => {
+    expect(getPresenceMeasurement("room")).toBe("room_occupancy");
+  });
+
+  it('returns "zone_occupancy" for zone', () => {
+    expect(getPresenceMeasurement("zone")).toBe("zone_occupancy");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTrafficMeasurement
+// ---------------------------------------------------------------------------
+
+describe("getTrafficMeasurement", () => {
+  it('returns "traffic_floor_occupancy" for floor', () => {
+    expect(getTrafficMeasurement("floor")).toBe("traffic_floor_occupancy");
+  });
+
+  it('returns "traffic_room_occupancy" for room', () => {
+    expect(getTrafficMeasurement("room")).toBe("traffic_room_occupancy");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPresenceCoverageNote
+// ---------------------------------------------------------------------------
+
+describe("getPresenceCoverageNote", () => {
+  it('mentions "Zones support presence" for zone with 0 sensors', () => {
+    const note = getPresenceCoverageNote("zone", 0);
+    expect(note).toMatch(/Zones support presence/);
+  });
+
+  it('mentions "No presence sensors" for room with 0 sensors', () => {
+    const note = getPresenceCoverageNote("room", 0);
+    expect(note).toMatch(/No presence sensors/);
+  });
+
+  it('mentions "No presence sensors" for floor with 0 sensors', () => {
+    const note = getPresenceCoverageNote("floor", 0);
+    expect(note).toMatch(/No presence sensors/);
+  });
+
+  it('mentions "3 sensors" and "may not cover" for floor with 3 sensors', () => {
+    const note = getPresenceCoverageNote("floor", 3);
+    expect(note).toMatch(/3 sensors/);
+    expect(note).toMatch(/may not cover/);
+  });
+
+  it('mentions "2 sensors" for room with 2 sensors', () => {
+    const note = getPresenceCoverageNote("room", 2);
+    expect(note).toMatch(/2 sensors/);
+  });
+
+  it('does not mention "may not cover" for room', () => {
+    const note = getPresenceCoverageNote("room", 2);
+    expect(note).not.toMatch(/may not cover/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTrafficCoverageNote
+// ---------------------------------------------------------------------------
+
+describe("getTrafficCoverageNote", () => {
+  it('returns "Zones do not support traffic" for zone with 0 sensors', () => {
+    const note = getTrafficCoverageNote("zone", 0);
+    expect(note).toBe("Zones do not support traffic.");
+  });
+
+  it('returns "No main entrance sensors." for floor with 0 sensors', () => {
+    const note = getTrafficCoverageNote("floor", 0);
+    expect(note).toBe("No main entrance sensors.");
+  });
+
+  it('returns "No traffic sensors." for room with 0 sensors', () => {
+    const note = getTrafficCoverageNote("room", 0);
+    expect(note).toBe("No traffic sensors.");
+  });
+
+  it('mentions "2 main entrance sensors" for floor with 2 sensors', () => {
+    const note = getTrafficCoverageNote("floor", 2);
+    expect(note).toMatch(/2 main entrance sensors/);
+  });
+
+  it('mentions "2 sensors" for room with 2 sensors', () => {
+    const note = getTrafficCoverageNote("room", 2);
+    expect(note).toMatch(/2 sensors/);
+  });
+
+  it('does not mention "main entrance" for room', () => {
+    const note = getTrafficCoverageNote("room", 3);
+    expect(note).not.toMatch(/main entrance/);
+  });
+});


### PR DESCRIPTION
## Summary

Brings the 3 pre-existing tools (`search-assets`, `hardware-snapshot`, `get-asset-details`) up to the same quality bar established in PR #9 for the new tools.

- **search-assets**: `error: unknown` + `rethrowIfGraphQLError`, `Site[]` typing (was `any[]`), skip caching partial topology data
- **hardware-snapshot**: Use shared `isProductionSensor`/`isProductionHive`, typed `HardwareSnapshotResponse` (was `Record<string, unknown>`), `getBatteryStatus` returns `"unknown"` instead of `"healthy"` when no tracking data exists, removed `(device as any)` casts
- **get-asset-details**: Unknown asset IDs now reported as error entries instead of silently skipped
- Noise JSDoc comments removed across all 3 files

## Test plan
- [x] `npm run typecheck` passes
- [x] 442 tests pass across 19 suites (was 396/17)
- [x] New: `graphql-helpers.test.ts` (22 tests) — `rethrowIfGraphQLError`, `isProductionSensor`, `isProductionHive`
- [x] New: `occupancy-helpers.test.ts` (24 tests) — `buildRecommendation`, measurement/coverage helpers
- [x] Updated: `battery-status.test.ts` — 3 tests updated for "healthy" → "unknown" behavior change