### PR TITLE
Prepare for npm publish: fix bin entry, add metadata, rewrite README

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to npm
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    name: Build & Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-03-20
+
 ### Added
-- Project scaffolding (TypeScript, ESLint v9, Prettier, Vitest)
-- Pre-commit hooks (typecheck, tests, secret scan, file size limits, lint/format)
-- CI workflow (GitHub Actions: typecheck, test, lint, build)
-- Bot caller workflows (pr-review, remediate, developer, maintainer, enrich)
+- 10 MCP tools for occupancy and asset data:
+  - `butlr_search_assets` — fuzzy search across sites, buildings, floors, rooms, sensors
+  - `butlr_get_asset_details` — comprehensive asset details with batch support
+  - `butlr_hardware_snapshot` — device health: online/offline status, battery levels
+  - `butlr_available_rooms` — find unoccupied rooms by capacity and tags
+  - `butlr_space_busyness` — current occupancy with qualitative labels and trends
+  - `butlr_traffic_flow` — entry/exit counts with hourly breakdown
+  - `butlr_list_topology` — org hierarchy tree with depth control
+  - `butlr_fetch_entity_details` — selective field fetching by entity ID
+  - `butlr_get_occupancy_timeseries` — historical occupancy data
+  - `butlr_get_current_occupancy` — real-time occupancy snapshot
+- GraphQL and REST API clients with OAuth2 token refresh
+- Topology and occupancy caching with configurable TTL
+- MCP error translation (AUTH_EXPIRED, RATE_LIMITED, VALIDATION_FAILED)
+- npm package configuration for one-shot install via `npx`
+- GitHub Actions CI and publish workflows
+- Project scaffolding: TypeScript strict mode, ESLint v9, Prettier, Vitest
+- Pre-commit hooks: typecheck, tests, secret scanning, file size limits
 - MIT license, security policy, contributing guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to the Butlr MCP Server!
 ## Development Setup
 
 ### Prerequisites
-- Node.js >= 18.0.0
+- Node.js >= 20.0.0
 - npm >= 9.0.0
 
 ### Getting Started

--- a/README.md
+++ b/README.md
@@ -1,52 +1,104 @@
 # Butlr MCP Server
 
+[![npm version](https://img.shields.io/npm/v/@butlr/butlr-mcp-server.svg)](https://www.npmjs.com/package/@butlr/butlr-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen.svg)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 
-A Model Context Protocol (MCP) server that connects AI assistants to Butlr's occupancy sensing platform. Query real-time space utilization, search facility assets, and analyze occupancy patterns using natural language.
+A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that connects AI assistants to [Butlr's](https://www.butlr.com) occupancy sensing platform. Query real-time space utilization, search facility assets, and analyze occupancy patterns through natural language.
 
-> **Status:** In development (v0.1.0)
+## Quick Start
 
-## Prerequisites
+### Claude Desktop
 
-- Node.js 18 or higher
-- Butlr API credentials (OAuth2 client ID and secret)
-- An MCP-compatible client (Claude Desktop, VS Code, etc.)
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
-## Development
+```json
+{
+  "mcpServers": {
+    "butlr": {
+      "command": "npx",
+      "args": ["-y", "@butlr/butlr-mcp-server@latest"],
+      "env": {
+        "BUTLR_CLIENT_ID": "your_client_id",
+        "BUTLR_CLIENT_SECRET": "your_client_secret",
+        "BUTLR_ORG_ID": "your_org_id"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
 
 ```bash
-# Install dependencies
-npm install
-
-# Build TypeScript
-npm run build
-
-# Run tests
-npm test
-
-# Type checking
-npm run typecheck
-
-# Lint
-npm run lint
-
-# Development with hot-reload
-npm run dev
-
-# Development with debug logging
-npm run dev:debug
+claude mcp add butlr -- npx -y @butlr/butlr-mcp-server@latest
 ```
+
+Then set environment variables in your shell or `.env` file:
+
+```bash
+export BUTLR_CLIENT_ID=your_client_id
+export BUTLR_CLIENT_SECRET=your_client_secret
+export BUTLR_ORG_ID=your_org_id
+```
+
+### VS Code (Copilot)
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "butlr": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@butlr/butlr-mcp-server@latest"],
+      "env": {
+        "BUTLR_CLIENT_ID": "your_client_id",
+        "BUTLR_CLIENT_SECRET": "your_client_secret",
+        "BUTLR_ORG_ID": "your_org_id"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "butlr": {
+      "command": "npx",
+      "args": ["-y", "@butlr/butlr-mcp-server@latest"],
+      "env": {
+        "BUTLR_CLIENT_ID": "your_client_id",
+        "BUTLR_CLIENT_SECRET": "your_client_secret",
+        "BUTLR_ORG_ID": "your_org_id"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description | Example Question |
+|------|-------------|-----------------|
+| `butlr_search_assets` | Search for assets (sites, buildings, floors, rooms, sensors) by name with fuzzy matching | "Find the main lobby" |
+| `butlr_get_asset_details` | Get comprehensive details for specific assets by ID with batch support | "Show me details for Conference Room 401" |
+| `butlr_hardware_snapshot` | Device health check: online/offline status and battery levels across your portfolio | "Which sensors need battery replacement?" |
+| `butlr_available_rooms` | Find currently unoccupied rooms, filterable by capacity and tags | "Are there any free conference rooms right now?" |
+| `butlr_space_busyness` | Current occupancy with qualitative labels (quiet/moderate/busy) and trend comparison | "How busy is the cafe right now?" |
+| `butlr_traffic_flow` | Entry/exit counts with hourly breakdown for traffic-mode sensors | "How many people entered the lobby today?" |
+| `butlr_list_topology` | Display org hierarchy tree with flexible depth control | "Show me all floors in Building 2" |
+| `butlr_fetch_entity_details` | Retrieve specific fields for entities by ID (minimal token usage) | "What's the timezone for this site?" |
+| `butlr_get_occupancy_timeseries` | Historical occupancy data with configurable time ranges | "Show occupancy trends for Floor 3 this week" |
+| `butlr_get_current_occupancy` | Real-time occupancy snapshot (last 5 minutes median) | "How many people are on Floor 2 right now?" |
 
 ## Configuration
-
-Create a `.env` file in the project root:
-
-```bash
-BUTLR_CLIENT_ID=your_client_id
-BUTLR_CLIENT_SECRET=your_client_secret
-BUTLR_ORG_ID=your_org_id
-```
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
@@ -58,15 +110,39 @@ BUTLR_ORG_ID=your_org_id
 | `MCP_CACHE_TOPO_TTL` | No | `600` | Topology cache TTL (seconds) |
 | `DEBUG` | No | - | Set to `butlr-mcp` for verbose logging |
 
+## Getting API Credentials
+
+Contact your Butlr account representative or visit [butlr.com](https://www.butlr.com) to obtain API credentials for your organization.
+
+## Troubleshooting
+
+**Authentication errors** — Verify your `BUTLR_CLIENT_ID`, `BUTLR_CLIENT_SECRET`, and `BUTLR_ORG_ID` are correct. Tokens are refreshed automatically.
+
+**Rate limiting** — The server handles rate limits automatically with retry logic. If you see persistent rate limit errors, reduce the frequency of requests.
+
+**No data returned** — Ensure your organization has active sensors deployed. Use `butlr_search_assets` to verify your org has discoverable assets.
+
+**Debug logging** — Set `DEBUG=butlr-mcp` in your environment to see detailed request/response logs on stderr.
+
+## Development
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full development workflow and standards.
+
+```bash
+npm install          # Install dependencies
+npm run build        # Build TypeScript
+npm test             # Run tests (442 tests)
+npm run typecheck    # Type checking
+npm run lint         # ESLint
+npm run dev          # Dev with hot-reload
+npm run dev:debug    # Dev with debug logging
+```
+
 ## Security
 
-- Never commit credentials to version control
 - All tools enforce read-only API access
+- Never commit credentials to version control
 - See [SECURITY.md](SECURITY.md) for vulnerability disclosure
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow and standards.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,25 @@
 
 A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that connects AI assistants to [Butlr's](https://www.butlr.com) occupancy sensing platform. Query real-time space utilization, search facility assets, and analyze occupancy patterns through natural language.
 
+### What you can do
+
+- **Find available spaces** — "Are there any free conference rooms right now with capacity for 8?"
+- **Monitor occupancy** — "How busy is the cafe? Should I head there now?"
+- **Analyze trends** — "Show me occupancy patterns for Floor 3 over the past week"
+- **Search your portfolio** — "Find all rooms named 'huddle' across Building 2"
+- **Check sensor health** — "Which sensors are offline or need battery replacement?"
+- **Track foot traffic** — "How many people entered the main lobby today?"
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 20 or higher
+- An MCP-compatible client ([Claude Desktop](https://claude.ai/download), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [VS Code](https://code.visualstudio.com/), [Cursor](https://cursor.com/), etc.)
+- Butlr API credentials (OAuth2 client ID, client secret, and organization ID) — see [Getting API Credentials](#getting-api-credentials)
+
 ## Quick Start
 
-### Claude Desktop
+<details open>
+<summary><strong>Claude Desktop</strong></summary>
 
 Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
@@ -28,7 +44,10 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 }
 ```
 
-### Claude Code
+</details>
+
+<details>
+<summary><strong>Claude Code</strong></summary>
 
 ```bash
 claude mcp add butlr -- npx -y @butlr/butlr-mcp-server@latest
@@ -42,7 +61,10 @@ export BUTLR_CLIENT_SECRET=your_client_secret
 export BUTLR_ORG_ID=your_org_id
 ```
 
-### VS Code (Copilot)
+</details>
+
+<details>
+<summary><strong>VS Code (Copilot)</strong></summary>
 
 Add to `.vscode/mcp.json`:
 
@@ -63,7 +85,10 @@ Add to `.vscode/mcp.json`:
 }
 ```
 
-### Cursor
+</details>
+
+<details>
+<summary><strong>Cursor</strong></summary>
 
 Add to `.cursor/mcp.json`:
 
@@ -83,10 +108,25 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
+</details>
+
+<details>
+<summary><strong>Other MCP clients</strong></summary>
+
+For any MCP client that supports stdio transport, use this command:
+
+```
+npx -y @butlr/butlr-mcp-server@latest
+```
+
+Pass the required environment variables (`BUTLR_CLIENT_ID`, `BUTLR_CLIENT_SECRET`, `BUTLR_ORG_ID`) through your client's configuration.
+
+</details>
+
 ## Available Tools
 
-| Tool | Description | Example Question |
-|------|-------------|-----------------|
+| Tool | Description | Try asking... |
+|------|-------------|---------------|
 | `butlr_search_assets` | Search for assets (sites, buildings, floors, rooms, sensors) by name with fuzzy matching | "Find the main lobby" |
 | `butlr_get_asset_details` | Get comprehensive details for specific assets by ID with batch support | "Show me details for Conference Room 401" |
 | `butlr_hardware_snapshot` | Device health check: online/offline status and battery levels across your portfolio | "Which sensors need battery replacement?" |
@@ -97,6 +137,8 @@ Add to `.cursor/mcp.json`:
 | `butlr_fetch_entity_details` | Retrieve specific fields for entities by ID (minimal token usage) | "What's the timezone for this site?" |
 | `butlr_get_occupancy_timeseries` | Historical occupancy data with configurable time ranges | "Show occupancy trends for Floor 3 this week" |
 | `butlr_get_current_occupancy` | Real-time occupancy snapshot (last 5 minutes median) | "How many people are on Floor 2 right now?" |
+
+All tools are **read-only** — the server cannot modify any data in your Butlr account.
 
 ## Configuration
 
@@ -112,7 +154,11 @@ Add to `.cursor/mcp.json`:
 
 ## Getting API Credentials
 
-Contact your Butlr account representative or visit [butlr.com](https://www.butlr.com) to obtain API credentials for your organization.
+To use this MCP server, you need OAuth2 API credentials from Butlr:
+
+1. **Contact your Butlr account representative** or visit [butlr.com](https://www.butlr.com) to request API access
+2. You will receive a **Client ID**, **Client Secret**, and **Organization ID**
+3. These credentials provide read-only access scoped to your organization's data
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@apollo/client": "^4.0.7",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "commander": "^12.1.0",
         "dotenv": "^16.4.5",
         "graphql": "^16.11.0",
         "lru-cache": "^11.0.2",
@@ -19,7 +18,7 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "butlr-mcp": "bin/cli.js"
+        "butlr-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.10.2",
@@ -2257,15 +2256,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,17 @@
   "description": "Model Context Protocol server providing secure, read-only access to Butlr occupancy and asset data",
   "type": "module",
   "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "bin": {
-    "butlr-mcp": "./bin/cli.js"
+    "butlr-mcp": "./dist/index.js"
   },
   "files": [
-    "dist",
-    "bin"
+    "dist"
   ],
   "scripts": {
     "dev": "tsx src/index.ts",
@@ -31,22 +36,35 @@
   },
   "keywords": [
     "mcp",
+    "mcp-server",
     "model-context-protocol",
     "butlr",
     "occupancy",
     "sensor",
+    "iot",
+    "smart-building",
     "graphql",
     "api"
   ],
   "author": "Butlr",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/butlrtechnologies/butlr-mcp.git"
+  },
+  "homepage": "https://github.com/butlrtechnologies/butlr-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/butlrtechnologies/butlr-mcp/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=20.0.0"
   },
   "dependencies": {
     "@apollo/client": "^4.0.7",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "graphql": "^16.11.0",
     "lru-cache": "^11.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**", "**/__mocks__/**", "**/__fixtures__/**"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,9 +15,7 @@ export default defineConfig({
         "**/__tests__/",
         "**/__mocks__/",
         "**/__fixtures__/",
-        "src/cli.ts",
         "src/index.ts",
-        "bin/**",
         "scripts/**",
       ],
       thresholds: {


### PR DESCRIPTION
## Summary

- Fix broken bin entry: point directly at `dist/index.js` (was `./bin/cli.js` which never existed). Matches standard MCP pattern (`@playwright/mcp`, `@notionhq/notion-mcp-server`).
- Remove unused `commander` dependency
- Add `publishConfig` (public), `repository`, `homepage`, `bugs`, `exports` to package.json
- Exclude test/mock/fixture files from tsc build output (were leaking into npm tarball)
- Rewrite README: installation configs for Claude Desktop/Code/VS Code/Cursor, tool summary table, troubleshooting guide
- Fix Node.js version in CONTRIBUTING.md (18 -> 20)
- Add GitHub Actions publish workflow (`npm publish --provenance` on `v*` tag)
- Add CHANGELOG 0.1.0 release section

## After merge

1. `git tag v0.1.0 && git push origin v0.1.0` triggers the publish workflow
2. Verify: `npx -y @butlr/butlr-mcp-server@latest` starts the server
3. Submit to MCP registries (Official MCP Registry, Smithery, mcp.so)

## Test plan

- [x] `npm run typecheck` passes
- [x] All 442 tests pass
- [x] `npm pack --dry-run` shows 135 files (no test/mock files)
- [x] `npm run rebuild` succeeds
- [ ] After publish: `npx -y @butlr/butlr-mcp-server@latest` starts stdio server
- [ ] MCP client config works in Claude Desktop