### PR TITLE
Remove --provenance from publish (requires public repo)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,6 @@ jobs:
         run: npm run build
 
       - name: Publish
-        run: npm publish --provenance
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `--provenance` flag from `npm publish` in the publish workflow
- Provenance requires a public source repository; ours is still private
- Will re-add `--provenance` when the repo goes public

## After merge

Delete the `v0.1.0` tag and re-create it to trigger a fresh publish run.