### PR TITLE
Drop undici for built-in fetch, lower Node req to 18+, update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 - Replace `undici` with built-in `fetch()` — lowers Node.js requirement from 20 to 18
-- Remove `BUTLR_ORG_ID` from required env vars (API tokens are already org-scoped)
+- Remove `BUTLR_ORG_ID` from required env vars
 - Update Claude Code setup docs to use `-e` flags for env vars
 - Expand "Getting API Credentials" with self-service instructions for app.butlr.io
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-03-20
+
+### Changed
+- Replace `undici` with built-in `fetch()` — lowers Node.js requirement from 20 to 18
+- Remove `BUTLR_ORG_ID` from required env vars (API tokens are already org-scoped)
+- Update Claude Code setup docs to use `-e` flags for env vars
+- Expand "Getting API Credentials" with self-service instructions for app.butlr.io
+
+### Added
+- `llms.txt` for LLM-assisted installation
+
 ## [0.1.0] - 2026-03-20
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to the Butlr MCP Server!
 ## Development Setup
 
 ### Prerequisites
-- Node.js >= 20.0.0
+- Node.js >= 18.0.0
 - npm >= 9.0.0
 
 ### Getting Started

--- a/README.md
+++ b/README.md
@@ -50,15 +50,11 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 <summary><strong>Claude Code</strong></summary>
 
 ```bash
-claude mcp add butlr -- npx -y @butlr/butlr-mcp-server@latest
-```
-
-Then set environment variables in your shell or `.env` file:
-
-```bash
-export BUTLR_CLIENT_ID=your_client_id
-export BUTLR_CLIENT_SECRET=your_client_secret
-export BUTLR_ORG_ID=your_org_id
+claude mcp add butlr \
+  -e BUTLR_CLIENT_ID=your_client_id \
+  -e BUTLR_CLIENT_SECRET=your_client_secret \
+  -e BUTLR_ORG_ID=your_org_id \
+  -- npx -y @butlr/butlr-mcp-server@latest
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that co
 
 - [Node.js](https://nodejs.org/) 18 or higher
 - An MCP-compatible client ([Claude Desktop](https://claude.ai/download), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [VS Code](https://code.visualstudio.com/), [Cursor](https://cursor.com/), etc.)
-- Butlr API credentials (OAuth2 client ID, client secret, and organization ID) — see [Getting API Credentials](#getting-api-credentials)
+- Butlr API token — see [Getting API Credentials](#getting-api-credentials)
 
 ## Quick Start
 
@@ -36,8 +36,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
       "args": ["-y", "@butlr/butlr-mcp-server@latest"],
       "env": {
         "BUTLR_CLIENT_ID": "your_client_id",
-        "BUTLR_CLIENT_SECRET": "your_client_secret",
-        "BUTLR_ORG_ID": "your_org_id"
+        "BUTLR_CLIENT_SECRET": "your_client_secret"
       }
     }
   }
@@ -53,7 +52,6 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 claude mcp add butlr \
   -e BUTLR_CLIENT_ID=your_client_id \
   -e BUTLR_CLIENT_SECRET=your_client_secret \
-  -e BUTLR_ORG_ID=your_org_id \
   -- npx -y @butlr/butlr-mcp-server@latest
 ```
 
@@ -73,8 +71,7 @@ Add to `.vscode/mcp.json`:
       "args": ["-y", "@butlr/butlr-mcp-server@latest"],
       "env": {
         "BUTLR_CLIENT_ID": "your_client_id",
-        "BUTLR_CLIENT_SECRET": "your_client_secret",
-        "BUTLR_ORG_ID": "your_org_id"
+        "BUTLR_CLIENT_SECRET": "your_client_secret"
       }
     }
   }
@@ -96,8 +93,7 @@ Add to `.cursor/mcp.json`:
       "args": ["-y", "@butlr/butlr-mcp-server@latest"],
       "env": {
         "BUTLR_CLIENT_ID": "your_client_id",
-        "BUTLR_CLIENT_SECRET": "your_client_secret",
-        "BUTLR_ORG_ID": "your_org_id"
+        "BUTLR_CLIENT_SECRET": "your_client_secret"
       }
     }
   }
@@ -115,7 +111,7 @@ For any MCP client that supports stdio transport, use this command:
 npx -y @butlr/butlr-mcp-server@latest
 ```
 
-Pass the required environment variables (`BUTLR_CLIENT_ID`, `BUTLR_CLIENT_SECRET`, `BUTLR_ORG_ID`) through your client's configuration.
+Pass the required environment variables (`BUTLR_CLIENT_ID`, `BUTLR_CLIENT_SECRET`) through your client's configuration.
 
 </details>
 
@@ -140,9 +136,8 @@ All tools are **read-only** — the server cannot modify any data in your Butlr 
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `BUTLR_CLIENT_ID` | **Yes** | - | OAuth2 client ID |
-| `BUTLR_CLIENT_SECRET` | **Yes** | - | OAuth2 client secret |
-| `BUTLR_ORG_ID` | **Yes** | - | Organization ID |
+| `BUTLR_CLIENT_ID` | **Yes** | - | API token client ID |
+| `BUTLR_CLIENT_SECRET` | **Yes** | - | API token client secret |
 | `BUTLR_BASE_URL` | No | `https://api.butlr.io` | API base URL |
 | `BUTLR_TIMEZONE` | No | `UTC` | Default timezone |
 | `MCP_CACHE_TOPO_TTL` | No | `600` | Topology cache TTL (seconds) |
@@ -150,15 +145,16 @@ All tools are **read-only** — the server cannot modify any data in your Butlr 
 
 ## Getting API Credentials
 
-To use this MCP server, you need OAuth2 API credentials from Butlr:
+1. Log in to [app.butlr.io](https://app.butlr.io)
+2. Click your username in the top-right corner, then **Account Settings**
+3. Go to **API Tokens** and create a new token
+4. Copy the **Client ID** and **Client Secret**
 
-1. **Contact your Butlr account representative** or visit [butlr.com](https://www.butlr.com) to request API access
-2. You will receive a **Client ID**, **Client Secret**, and **Organization ID**
-3. These credentials provide read-only access scoped to your organization's data
+You need **edit access** to Butlr Studio to create API tokens. If you don't have edit permissions, ask someone in your organization who does, or contact your Butlr sales representative or [submit a support ticket](https://www.butlr.com).
 
 ## Troubleshooting
 
-**Authentication errors** — Verify your `BUTLR_CLIENT_ID`, `BUTLR_CLIENT_SECRET`, and `BUTLR_ORG_ID` are correct. Tokens are refreshed automatically.
+**Authentication errors** — Verify your `BUTLR_CLIENT_ID` and `BUTLR_CLIENT_SECRET` are correct. Tokens are refreshed automatically.
 
 **Rate limiting** — The server handles rate limits automatically with retry logic. If you see persistent rate limit errors, reduce the frequency of requests.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@butlr/butlr-mcp-server.svg)](https://www.npmjs.com/package/@butlr/butlr-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen.svg)](https://nodejs.org/)
 
 A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that connects AI assistants to [Butlr's](https://www.butlr.com) occupancy sensing platform. Query real-time space utilization, search facility assets, and analyze occupancy patterns through natural language.
 
@@ -17,7 +17,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that co
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) 20 or higher
+- [Node.js](https://nodejs.org/) 18 or higher
 - An MCP-compatible client ([Claude Desktop](https://claude.ai/download), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [VS Code](https://code.visualstudio.com/), [Cursor](https://cursor.com/), etc.)
 - Butlr API credentials (OAuth2 client ID, client secret, and organization ID) — see [Getting API Credentials](#getting-api-credentials)
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,125 @@
+# Butlr MCP Server
+
+> MCP server for querying Butlr occupancy sensors and facility data through natural language.
+
+## Installation
+
+Install via npx — no global install needed. Requires Node.js 18+.
+
+### Claude Code
+
+```bash
+claude mcp add butlr \
+  -e BUTLR_CLIENT_ID=<client_id> \
+  -e BUTLR_CLIENT_SECRET=<client_secret> \
+  -- npx -y @butlr/butlr-mcp-server@latest
+```
+
+### Claude Desktop
+
+Add to the MCP config file (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows):
+
+```json
+{
+  "mcpServers": {
+    "butlr": {
+      "command": "npx",
+      "args": ["-y", "@butlr/butlr-mcp-server@latest"],
+      "env": {
+        "BUTLR_CLIENT_ID": "<client_id>",
+        "BUTLR_CLIENT_SECRET": "<client_secret>"
+      }
+    }
+  }
+}
+```
+
+### VS Code (Copilot)
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "butlr": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@butlr/butlr-mcp-server@latest"],
+      "env": {
+        "BUTLR_CLIENT_ID": "<client_id>",
+        "BUTLR_CLIENT_SECRET": "<client_secret>"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "butlr": {
+      "command": "npx",
+      "args": ["-y", "@butlr/butlr-mcp-server@latest"],
+      "env": {
+        "BUTLR_CLIENT_ID": "<client_id>",
+        "BUTLR_CLIENT_SECRET": "<client_secret>"
+      }
+    }
+  }
+}
+```
+
+### Other MCP Clients
+
+Use this command with any stdio-compatible MCP client:
+
+```
+npx -y @butlr/butlr-mcp-server@latest
+```
+
+Required environment variables: `BUTLR_CLIENT_ID`, `BUTLR_CLIENT_SECRET`.
+
+## Getting API Credentials
+
+Users create API tokens in Butlr Studio:
+
+1. Log in to app.butlr.io
+2. Click username in top-right corner → Account Settings → API Tokens
+3. Create a new token and copy the Client ID and Client Secret
+
+Users need edit access to Butlr Studio to create tokens. If they don't have edit permissions, they should ask someone in their organization who does, contact their Butlr sales representative, or submit a support ticket at butlr.com.
+
+## Required Environment Variables
+
+- `BUTLR_CLIENT_ID` — API token client ID (required)
+- `BUTLR_CLIENT_SECRET` — API token client secret (required)
+
+## Optional Environment Variables
+
+- `BUTLR_BASE_URL` — API base URL (default: https://api.butlr.io)
+- `BUTLR_TIMEZONE` — Default timezone (default: UTC)
+- `MCP_CACHE_TOPO_TTL` — Topology cache TTL in seconds (default: 600)
+- `DEBUG` — Set to `butlr-mcp` for verbose logging
+
+## Available Tools
+
+- `butlr_search_assets` — Search for assets (sites, buildings, floors, rooms, sensors) by name with fuzzy matching
+- `butlr_get_asset_details` — Get comprehensive details for specific assets by ID with batch support
+- `butlr_hardware_snapshot` — Device health check: online/offline status and battery levels
+- `butlr_available_rooms` — Find currently unoccupied rooms, filterable by capacity and tags
+- `butlr_space_busyness` — Current occupancy with qualitative labels (quiet/moderate/busy) and trend comparison
+- `butlr_traffic_flow` — Entry/exit counts with hourly breakdown for traffic-mode sensors
+- `butlr_list_topology` — Display org hierarchy tree with flexible depth control
+- `butlr_fetch_entity_details` — Retrieve specific fields for entities by ID (minimal token usage)
+- `butlr_get_occupancy_timeseries` — Historical occupancy data with configurable time ranges
+- `butlr_get_current_occupancy` — Real-time occupancy snapshot (last 5 minutes median)
+
+All tools are read-only. The server cannot modify any data in the user's Butlr account.
+
+## About Butlr
+
+Butlr (butlr.com) is an occupancy sensing platform for smart buildings. It uses anonymous thermal sensors to measure how spaces are being used — occupancy counts, traffic flow, and space utilization — without cameras or personally identifiable data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "dotenv": "^16.4.5",
         "graphql": "^16.11.0",
         "lru-cache": "^11.0.2",
-        "undici": "^7.16.0",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -5229,15 +5228,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@apollo/client": "^4.0.7",
@@ -68,7 +68,6 @@
     "dotenv": "^16.4.5",
     "graphql": "^16.11.0",
     "lru-cache": "^11.0.2",
-    "undici": "^7.16.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@butlr/butlr-mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Model Context Protocol server providing secure, read-only access to Butlr occupancy and asset data",
   "type": "module",
   "main": "dist/index.js",

--- a/src/clients/reporting-client.ts
+++ b/src/clients/reporting-client.ts
@@ -1,4 +1,3 @@
-import { request as httpRequest } from "undici";
 import { authClient } from "./auth-client.js";
 
 /**
@@ -207,7 +206,7 @@ export async function queryReporting(requestBody: ReportingRequest): Promise<Rep
     const token = await authClient.getToken();
 
     // Make request
-    const response = await httpRequest(REPORTING_ENDPOINT, {
+    const response = await fetch(REPORTING_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -216,18 +215,18 @@ export async function queryReporting(requestBody: ReportingRequest): Promise<Rep
       body: JSON.stringify(requestBody),
     });
 
-    if (response.statusCode !== 200) {
-      const errorBody = await response.body.text();
+    if (!response.ok) {
+      const errorBody = await response.text();
       if (process.env.DEBUG) {
         console.error(`[reporting-client] API error body: ${errorBody}`);
       }
       throw new ApiError(
-        response.statusCode,
-        `Butlr API error (${response.statusCode}). Enable DEBUG=butlr-mcp for details.`
+        response.status,
+        `Butlr API error (${response.status}). Enable DEBUG=butlr-mcp for details.`
       );
     }
 
-    const data = (await response.body.json()) as ReportingResponse;
+    const data = (await response.json()) as ReportingResponse;
 
     if (process.env.DEBUG) {
       console.error(`[reporting-client] Response: ${data.data?.length || 0} data points`);

--- a/src/clients/stats-client.ts
+++ b/src/clients/stats-client.ts
@@ -1,4 +1,3 @@
-import { request as httpRequest } from "undici";
 import { authClient } from "./auth-client.js";
 import { ApiError } from "./reporting-client.js";
 
@@ -71,7 +70,7 @@ export async function queryStats(statsRequest: StatsRequest): Promise<StatsRespo
     const token = await authClient.getToken();
 
     // Make request
-    const response = await httpRequest(STATS_ENDPOINT, {
+    const response = await fetch(STATS_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -80,11 +79,11 @@ export async function queryStats(statsRequest: StatsRequest): Promise<StatsRespo
       body: JSON.stringify(statsRequest),
     });
 
-    if (response.statusCode !== 200) {
-      const errorBody = await response.body.text();
+    if (!response.ok) {
+      const errorBody = await response.text();
 
       // Special handling for 504 Gateway Timeout
-      if (response.statusCode === 504) {
+      if (response.status === 504) {
         console.error(`[stats-client] 504 Gateway Timeout - stats service may be overloaded`);
         throw new ApiError(
           504,
@@ -96,12 +95,12 @@ export async function queryStats(statsRequest: StatsRequest): Promise<StatsRespo
         console.error(`[stats-client] API error body: ${errorBody}`);
       }
       throw new ApiError(
-        response.statusCode,
-        `Butlr API error (${response.statusCode}). Enable DEBUG=butlr-mcp for details.`
+        response.status,
+        `Butlr API error (${response.status}). Enable DEBUG=butlr-mcp for details.`
       );
     }
 
-    const data = (await response.body.json()) as StatsResponse;
+    const data = (await response.json()) as StatsResponse;
 
     if (process.env.DEBUG) {
       console.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { registerGetOccupancyTimeseries } from "./tools/butlr-get-occupancy-time
 import { registerGetCurrentOccupancy } from "./tools/butlr-get-current-occupancy.js";
 
 const SERVER_NAME = "butlr-mcp-server";
-const SERVER_VERSION = "0.1.0";
+const SERVER_VERSION = "0.1.1";
 
 const server = new McpServer({
   name: SERVER_NAME,


### PR DESCRIPTION
## Summary

- Replace `undici` with built-in `fetch()` in reporting-client and stats-client
- Remove `undici` dependency (required Node >= 20.18.1, causing crashes on Node 18)
- Lower `engines` requirement from Node 20 to Node 18
- Update Claude Code setup docs to use `-e` flags for env vars
- Update README badge and prerequisites

## Problem

When MCP clients spawn the server with Node 18 (a common default), `undici@7.x` crashes with `ReferenceError: File is not defined` because it requires Node 20+. Built-in `fetch` is available since Node 18 and works identically.

## Test plan

- [x] `npm run typecheck` passes
- [x] All 442 tests pass
- [x] `npm run build` succeeds
- [ ] After publish: verify `npx @butlr/butlr-mcp-server` works on Node 18