### PR TITLE
Pre-public release cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@
 # Required: Butlr API credentials (OAuth2 Client Credentials)
 BUTLR_CLIENT_ID=your_client_id_here
 BUTLR_CLIENT_SECRET=your_client_secret_here
+
+# Optional: Organization ID (auto-detected if not set)
 BUTLR_ORG_ID=your_organization_id_here
 
 # Optional: API configuration

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Report a bug with the Butlr MCP Server
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**Steps to reproduce**
+1. Configure MCP server with...
+2. Ask the assistant to...
+3. See error...
+
+**Expected behavior**
+What you expected to happen.
+
+**Error output**
+If applicable, paste the error message or debug output (`DEBUG=butlr-mcp`).
+
+**Environment**
+- Node.js version:
+- MCP client (Claude Desktop / Claude Code / VS Code / Cursor / other):
+- OS:
+- Package version (`npm list @butlr/butlr-mcp-server`):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest a new tool or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Use case**
+Describe what you're trying to accomplish.
+
+**Proposed solution**
+How you'd like the feature to work.
+
+**Alternatives considered**
+Any workarounds or alternative approaches you've tried.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Description
+
+Brief description of what this PR does.
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm test` passes
+- [ ] `npm run lint` passes
+- [ ] Documentation updated (if applicable)
+- [ ] No secrets or credentials committed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,17 @@ on:
 
 jobs:
   check:
-    name: Typecheck, Test, Lint
+    name: Typecheck, Test, Lint (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - run: npm ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ npm run format       # Prettier
 |----------|----------|---------|
 | `BUTLR_CLIENT_ID` | Yes | OAuth2 client ID |
 | `BUTLR_CLIENT_SECRET` | Yes | OAuth2 client secret |
-| `BUTLR_ORG_ID` | Yes | Organization ID |
+| `BUTLR_ORG_ID` | No | Organization ID (optional as of v0.1.1) |
 | `BUTLR_BASE_URL` | No | API base URL (default: `https://api.butlr.io`) |
 | `BUTLR_TIMEZONE` | No | Default timezone (default: `UTC`) |
 | `MCP_CACHE_TOPO_TTL` | No | Topology cache TTL in seconds (default: 600) |

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @butlrtechnologies/backend

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ npm test
 Every commit automatically runs:
 
 1. **Type checking** (`npm run typecheck`) - Ensures TypeScript types are valid
-2. **Full test suite** (`npm test`) - All 256 tests must pass (~600ms runtime)
+2. **Full test suite** (`npm test`) - All tests must pass
 3. **Secret file detection** - Blocks commits containing `.env`, `.pem`, `.key`, `.p12`, `.pfx` files
 4. **Secret pattern detection** - Scans for AWS keys, API tokens, JWTs in code
 5. **Large file detection** - Blocks files >500KB (suggest Git LFS or .gitignore)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Butlr Technologies
+Copyright (c) 2025-2026 Butlr Technologies
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/cache/occupancy-cache.ts
+++ b/src/cache/occupancy-cache.ts
@@ -1,4 +1,5 @@
 import { LRUCache } from "lru-cache";
+import { debug } from "../utils/debug.js";
 
 /**
  * Occupancy cache configuration
@@ -60,14 +61,10 @@ export function getCachedOccupancy(
   // Track cache hit/miss metrics
   if (cached) {
     recordCacheHit();
-    if (process.env.DEBUG) {
-      console.error(`[occupancy-cache] Cache HIT for ${assetId}`);
-    }
+    debug("occupancy-cache", `Cache HIT for ${assetId}`);
   } else {
     recordCacheMiss();
-    if (process.env.DEBUG) {
-      console.error(`[occupancy-cache] Cache MISS for ${assetId}`);
-    }
+    debug("occupancy-cache", `Cache MISS for ${assetId}`);
   }
 
   return cached;
@@ -96,11 +93,7 @@ export function getBulkCachedOccupancy(
     }
   }
 
-  if (process.env.DEBUG) {
-    console.error(
-      `[occupancy-cache] Bulk query: ${Object.keys(hits).length} hits, ${misses.length} misses`
-    );
-  }
+  debug("occupancy-cache", `Bulk query: ${Object.keys(hits).length} hits, ${misses.length} misses`);
 
   return { hits, misses };
 }
@@ -126,11 +119,10 @@ export function setCachedOccupancy(
 
   occupancyCache.set(key, entry);
 
-  if (process.env.DEBUG) {
-    console.error(
-      `[occupancy-cache] Cached occupancy for ${assetId}: ${occupancy} (TTL: ${CACHE_TTL_SECONDS / 1000}s)`
-    );
-  }
+  debug(
+    "occupancy-cache",
+    `Cached occupancy for ${assetId}: ${occupancy} (TTL: ${CACHE_TTL_SECONDS / 1000}s)`
+  );
 }
 
 /**
@@ -148,9 +140,7 @@ export function setBulkCachedOccupancy(
     setCachedOccupancy(entry.assetId, entry.occupancy, entry.assetType, entry.timestamp);
   }
 
-  if (process.env.DEBUG) {
-    console.error(`[occupancy-cache] Bulk cached ${entries.length} occupancy values`);
-  }
+  debug("occupancy-cache", `Bulk cached ${entries.length} occupancy values`);
 }
 
 /**
@@ -159,9 +149,7 @@ export function setBulkCachedOccupancy(
 export function clearOccupancyCache(): void {
   occupancyCache.clear();
 
-  if (process.env.DEBUG) {
-    console.error("[occupancy-cache] Cache cleared");
-  }
+  debug("occupancy-cache", "Cache cleared");
 }
 
 /**
@@ -177,8 +165,8 @@ export function invalidateAssetOccupancy(assetId: string): void {
     }
   }
 
-  if (process.env.DEBUG && deleted > 0) {
-    console.error(`[occupancy-cache] Invalidated ${deleted} cache entries for ${assetId}`);
+  if (deleted > 0) {
+    debug("occupancy-cache", `Invalidated ${deleted} cache entries for ${assetId}`);
   }
 }
 

--- a/src/cache/topology-cache.ts
+++ b/src/cache/topology-cache.ts
@@ -1,4 +1,5 @@
 import { LRUCache } from "lru-cache";
+import { debug } from "../utils/debug.js";
 
 /**
  * Topology cache configuration
@@ -49,10 +50,10 @@ export function generateTopologyCacheKey(
 export function getCachedTopology(key: string): CacheEntry | undefined {
   const cached = topologyCache.get(key);
 
-  if (cached && process.env.DEBUG) {
-    console.error(`[topology-cache] Cache HIT for key: ${key}`);
-  } else if (process.env.DEBUG) {
-    console.error(`[topology-cache] Cache MISS for key: ${key}`);
+  if (cached) {
+    debug("topology-cache", `Cache HIT for key: ${key}`);
+  } else {
+    debug("topology-cache", `Cache MISS for key: ${key}`);
   }
 
   return cached;
@@ -69,11 +70,7 @@ export function setCachedTopology(key: string, data: Record<string, unknown>): v
 
   topologyCache.set(key, entry);
 
-  if (process.env.DEBUG) {
-    console.error(
-      `[topology-cache] Cached data for key: ${key} (TTL: ${CACHE_TTL_SECONDS / 1000}s)`
-    );
-  }
+  debug("topology-cache", `Cached data for key: ${key} (TTL: ${CACHE_TTL_SECONDS / 1000}s)`);
 }
 
 /**
@@ -82,9 +79,7 @@ export function setCachedTopology(key: string, data: Record<string, unknown>): v
 export function clearTopologyCache(): void {
   topologyCache.clear();
 
-  if (process.env.DEBUG) {
-    console.error("[topology-cache] Cache cleared");
-  }
+  debug("topology-cache", "Cache cleared");
 }
 
 /**

--- a/src/clients/auth-client.ts
+++ b/src/clients/auth-client.ts
@@ -1,4 +1,5 @@
 import dotenv from "dotenv";
+import { debug } from "../utils/debug.js";
 
 dotenv.config();
 
@@ -40,15 +41,11 @@ class ButlrAuthClient {
 
     // Return cached token if still valid (with 5 minute buffer)
     if (this.token && this.tokenExpiry && Date.now() < this.tokenExpiry.getTime() - 5 * 60 * 1000) {
-      if (process.env.DEBUG) {
-        console.error("[auth-client] Using cached token");
-      }
+      debug("auth-client", "Using cached token");
       return this.token;
     }
 
-    if (process.env.DEBUG) {
-      console.error("[auth-client] Fetching new token...");
-    }
+    debug("auth-client", "Fetching new token...");
 
     // Fetch new token
     try {
@@ -80,9 +77,7 @@ class ButlrAuthClient {
       this.token = data.access_token;
       this.tokenExpiry = new Date(Date.now() + data.expires_in * 1000);
 
-      if (process.env.DEBUG) {
-        console.error(`[auth-client] Token acquired, expires at ${this.tokenExpiry.toISOString()}`);
-      }
+      debug("auth-client", `Token acquired, expires at ${this.tokenExpiry.toISOString()}`);
 
       return this.token;
     } catch (error) {

--- a/src/clients/graphql-client.ts
+++ b/src/clients/graphql-client.ts
@@ -2,6 +2,7 @@ import { ApolloClient, InMemoryCache, createHttpLink, from } from "@apollo/clien
 import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import { authClient } from "./auth-client.js";
+import { debug } from "../utils/debug.js";
 
 const BASE_URL = process.env.BUTLR_BASE_URL || "https://api.butlr.io";
 const GRAPHQL_ENDPOINT = `${BASE_URL}/api/v3/graphql`;
@@ -27,7 +28,7 @@ const authLink = setContext(async (_, { headers }) => {
       },
     };
   } catch (error) {
-    console.error("[graphql-client] Failed to get auth token:", error);
+    debug("graphql-client", "Failed to get auth token:", error);
     throw error;
   }
 });
@@ -49,7 +50,7 @@ const errorLink = onError((errorResponse) => {
 
   if (graphQLErrors) {
     for (const err of graphQLErrors) {
-      console.error(`[graphql-client] GraphQL error in ${operation.operationName}:`, err.message);
+      debug("graphql-client", `GraphQL error in ${operation.operationName}:`, err.message);
       if (err.extensions?.code === "UNAUTHENTICATED") {
         authClient.clearToken();
       }
@@ -57,10 +58,7 @@ const errorLink = onError((errorResponse) => {
   }
 
   if (networkError) {
-    console.error(
-      `[graphql-client] Network error in ${operation.operationName}:`,
-      networkError.message
-    );
+    debug("graphql-client", `Network error in ${operation.operationName}:`, networkError.message);
     if (networkError.statusCode === 401 || networkError.statusCode === 403) {
       authClient.clearToken();
     }
@@ -68,7 +66,7 @@ const errorLink = onError((errorResponse) => {
 
   // Fallback for Apollo 4.x single error field
   if (!graphQLErrors && !networkError && topError) {
-    console.error(`[graphql-client] Error in ${operation.operationName}:`, topError.message);
+    debug("graphql-client", `Error in ${operation.operationName}:`, topError.message);
     if (
       topError.message?.includes("UNAUTHENTICATED") ||
       topError.message?.includes("401") ||

--- a/src/clients/reporting-client.ts
+++ b/src/clients/reporting-client.ts
@@ -1,4 +1,5 @@
 import { authClient } from "./auth-client.js";
+import { debug } from "../utils/debug.js";
 
 /**
  * Structured API error with status code for proper error translation
@@ -174,18 +175,18 @@ export function getMeasurement(assetType: string): string {
  */
 export function normalizeTimestamp(rfc3339: string): string {
   if (!rfc3339) {
-    console.error(`[reporting-client] Invalid timestamp received: ${rfc3339}`);
+    debug("reporting-client", `Invalid timestamp received: ${rfc3339}`);
     return "";
   }
   try {
     const date = new Date(rfc3339);
     if (isNaN(date.getTime())) {
-      console.error(`[reporting-client] Invalid timestamp received: ${rfc3339}`);
+      debug("reporting-client", `Invalid timestamp received: ${rfc3339}`);
       return "";
     }
     return date.toISOString();
   } catch (error) {
-    console.error(`[reporting-client] Failed to normalize timestamp ${rfc3339}:`, error);
+    debug("reporting-client", `Failed to normalize timestamp ${rfc3339}:`, error);
     return "";
   }
 }
@@ -194,12 +195,7 @@ export function normalizeTimestamp(rfc3339: string): string {
  * Query v3 Reporting API
  */
 export async function queryReporting(requestBody: ReportingRequest): Promise<ReportingResponse> {
-  if (process.env.DEBUG) {
-    console.error(
-      `[reporting-client] POST ${REPORTING_ENDPOINT}`,
-      JSON.stringify(requestBody, null, 2)
-    );
-  }
+  debug("reporting-client", `POST ${REPORTING_ENDPOINT}`, JSON.stringify(requestBody, null, 2));
 
   try {
     // Get auth token
@@ -217,9 +213,7 @@ export async function queryReporting(requestBody: ReportingRequest): Promise<Rep
 
     if (!response.ok) {
       const errorBody = await response.text();
-      if (process.env.DEBUG) {
-        console.error(`[reporting-client] API error body: ${errorBody}`);
-      }
+      debug("reporting-client", `API error body: ${errorBody}`);
       throw new ApiError(
         response.status,
         `Butlr API error (${response.status}). Enable DEBUG=butlr-mcp for details.`
@@ -228,13 +222,11 @@ export async function queryReporting(requestBody: ReportingRequest): Promise<Rep
 
     const data = (await response.json()) as ReportingResponse;
 
-    if (process.env.DEBUG) {
-      console.error(`[reporting-client] Response: ${data.data?.length || 0} data points`);
-    }
+    debug("reporting-client", `Response: ${data.data?.length || 0} data points`);
 
     return data;
   } catch (error: any) {
-    console.error(`[reporting-client] Request failed:`, error);
+    debug("reporting-client", "Request failed:", error);
 
     // Translate common errors using structured ApiError
     if (error instanceof ApiError) {
@@ -437,8 +429,9 @@ export async function getCurrentOccupancy(
   const trafficResponse = trafficResult.status === "fulfilled" ? trafficResult.value : { data: [] };
 
   if (trafficResult.status === "rejected") {
-    console.error(
-      `[reporting-client] Traffic query failed (may not have traffic sensors):`,
+    debug(
+      "reporting-client",
+      "Traffic query failed (may not have traffic sensors):",
       trafficResult.reason
     );
   }

--- a/src/clients/stats-client.ts
+++ b/src/clients/stats-client.ts
@@ -1,5 +1,6 @@
 import { authClient } from "./auth-client.js";
 import { ApiError } from "./reporting-client.js";
+import { debug } from "../utils/debug.js";
 
 const BASE_URL = process.env.BUTLR_BASE_URL || "https://api.butlr.io";
 const STATS_ENDPOINT = `${BASE_URL}/api/v4/reporting/stats`;
@@ -61,9 +62,7 @@ export interface StatsResponse {
  * under heavy load. Implement fallback to client-side calculation if needed.
  */
 export async function queryStats(statsRequest: StatsRequest): Promise<StatsResponse> {
-  if (process.env.DEBUG) {
-    console.error(`[stats-client] POST ${STATS_ENDPOINT}`, JSON.stringify(statsRequest, null, 2));
-  }
+  debug("stats-client", `POST ${STATS_ENDPOINT}`, JSON.stringify(statsRequest, null, 2));
 
   try {
     // Get auth token
@@ -84,16 +83,14 @@ export async function queryStats(statsRequest: StatsRequest): Promise<StatsRespo
 
       // Special handling for 504 Gateway Timeout
       if (response.status === 504) {
-        console.error(`[stats-client] 504 Gateway Timeout - stats service may be overloaded`);
+        debug("stats-client", "504 Gateway Timeout - stats service may be overloaded");
         throw new ApiError(
           504,
           "Stats service temporarily unavailable (504). Try reducing the time range or number of assets."
         );
       }
 
-      if (process.env.DEBUG) {
-        console.error(`[stats-client] API error body: ${errorBody}`);
-      }
+      debug("stats-client", `API error body: ${errorBody}`);
       throw new ApiError(
         response.status,
         `Butlr API error (${response.status}). Enable DEBUG=butlr-mcp for details.`
@@ -102,15 +99,11 @@ export async function queryStats(statsRequest: StatsRequest): Promise<StatsRespo
 
     const data = (await response.json()) as StatsResponse;
 
-    if (process.env.DEBUG) {
-      console.error(
-        `[stats-client] Response: statistics for ${Object.keys(data.data || {}).length} assets`
-      );
-    }
+    debug("stats-client", `Response: statistics for ${Object.keys(data.data || {}).length} assets`);
 
     return data;
   } catch (error: any) {
-    console.error(`[stats-client] Request failed:`, error);
+    debug("stats-client", "Request failed:", error);
 
     // Translate common errors using structured ApiError
     if (error instanceof ApiError) {

--- a/src/errors/mcp-errors.ts
+++ b/src/errors/mcp-errors.ts
@@ -13,7 +13,7 @@ export function withToolErrorHandling(
       return await handler(args);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      debug("tool-error", message);
+      debug("tool-error", message, error);
       return {
         content: [{ type: "text" as const, text: message }],
         isError: true,

--- a/src/errors/mcp-errors.ts
+++ b/src/errors/mcp-errors.ts
@@ -1,3 +1,27 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { debug } from "../utils/debug.js";
+
+/**
+ * Wraps a tool handler to catch errors and return them as MCP tool errors
+ * with isError: true, so the LLM can see and handle the error.
+ */
+export function withToolErrorHandling(
+  handler: (args: Record<string, unknown>) => Promise<CallToolResult>
+): (args: Record<string, unknown>) => Promise<CallToolResult> {
+  return async (args) => {
+    try {
+      return await handler(args);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      debug("tool-error", message);
+      return {
+        content: [{ type: "text" as const, text: message }],
+        isError: true,
+      };
+    }
+  };
+}
+
 /**
  * Structural type for Apollo-like errors (ApolloError was removed in Apollo Client 4.0)
  * Narrowed from `any` to `unknown` with runtime property checks inside translateGraphQLError.
@@ -155,7 +179,7 @@ export function formatMCPError(error: MCPError): string {
     message += ` - retry after ${error.retryAfter}s`;
   }
 
-  if (error.details && process.env.DEBUG) {
+  if (error.details && (process.env.DEBUG === "butlr-mcp" || process.env.DEBUG === "*")) {
     message += `\nDetails: ${JSON.stringify(error.details, null, 2)}`;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerSearchAssets } from "./tools/butlr-search-assets.js";
@@ -11,9 +12,12 @@ import { registerListTopology } from "./tools/butlr-list-topology.js";
 import { registerFetchEntityDetails } from "./tools/butlr-fetch-entity-details.js";
 import { registerGetOccupancyTimeseries } from "./tools/butlr-get-occupancy-timeseries.js";
 import { registerGetCurrentOccupancy } from "./tools/butlr-get-current-occupancy.js";
+import { debug } from "./utils/debug.js";
+
+const require = createRequire(import.meta.url);
+const { version: SERVER_VERSION } = require("../package.json") as { version: string };
 
 const SERVER_NAME = "butlr-mcp-server";
-const SERVER_VERSION = "0.1.1";
 
 const server = new McpServer({
   name: SERVER_NAME,
@@ -36,10 +40,8 @@ async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
-  if (process.env.DEBUG === "butlr-mcp" || process.env.DEBUG === "*") {
-    console.error(`[${SERVER_NAME}] Server started on stdio transport`);
-    console.error(`[${SERVER_NAME}] Version: ${SERVER_VERSION}`);
-  }
+  debug(SERVER_NAME, "Server started on stdio transport");
+  debug(SERVER_NAME, `Version: ${SERVER_VERSION}`);
 }
 
 main().catch((error) => {

--- a/src/tools/butlr-available-rooms.ts
+++ b/src/tools/butlr-available-rooms.ts
@@ -8,6 +8,8 @@ import { buildAvailableRoomsSummary } from "../utils/natural-language.js";
 import { getCachedOccupancy, setBulkCachedOccupancy } from "../cache/occupancy-cache.js";
 import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
 import type { AvailableRoom, AvailableRoomsResponse, BuildingContext } from "../types/responses.js";
+import { debug } from "../utils/debug.js";
+import { withToolErrorHandling } from "../errors/mcp-errors.js";
 
 /** Shared shape — used by both registerTool (SDK schema) and full validation */
 const availableRoomsInputShape = {
@@ -239,12 +241,7 @@ const GET_ALL_ROOMS = gql`
  * Execute available rooms tool
  */
 export async function executeAvailableRooms(args: AvailableRoomsArgs) {
-  if (process.env.DEBUG) {
-    console.error(
-      `[available-rooms] Finding available rooms with filters:`,
-      JSON.stringify(args, null, 2)
-    );
-  }
+  debug("available-rooms", "Finding available rooms with filters:", JSON.stringify(args, null, 2));
 
   // Query rooms based on scope
   let rooms: Room[] = [];
@@ -327,9 +324,7 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
     throw error;
   }
 
-  if (process.env.DEBUG) {
-    console.error(`[available-rooms] Found ${rooms.length} rooms before filtering`);
-  }
+  debug("available-rooms", `Found ${rooms.length} rooms before filtering`);
 
   // Apply capacity filters and track rooms excluded due to missing capacity data
   const warnings: string[] = [];
@@ -379,9 +374,7 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
   // Get current occupancy for all rooms
   const roomIds = rooms.map((r) => r.id);
 
-  if (process.env.DEBUG) {
-    console.error(`[available-rooms] Querying occupancy for ${roomIds.length} rooms`);
-  }
+  debug("available-rooms", `Querying occupancy for ${roomIds.length} rooms`);
 
   // Check cache first
   const now = new Date();
@@ -399,11 +392,7 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
   let occupancyFetchFailed = false;
 
   if (uncachedRoomIds.length > 0) {
-    if (process.env.DEBUG) {
-      console.error(
-        `[available-rooms] Cache miss for ${uncachedRoomIds.length} rooms, querying API`
-      );
-    }
+    debug("available-rooms", `Cache miss for ${uncachedRoomIds.length} rooms, querying API`);
 
     try {
       const occupancyData = await getCurrentOccupancy("room", uncachedRoomIds);
@@ -424,7 +413,7 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
 
       setBulkCachedOccupancy(cacheEntries);
     } catch (error: unknown) {
-      console.error(`[available-rooms] Failed to get occupancy data:`, error);
+      debug("available-rooms", "Failed to get occupancy data:", error);
       occupancyFetchFailed = true;
     }
   }
@@ -479,9 +468,7 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
     }
   }
 
-  if (process.env.DEBUG) {
-    console.error(`[available-rooms] ${availableRooms.length} rooms available (occupancy=0)`);
-  }
+  debug("available-rooms", `${availableRooms.length} rooms available (occupancy=0)`);
 
   // Sort by capacity (largest first) and limit results
   availableRooms.sort((a, b) => (b.capacity?.max || 0) - (a.capacity?.max || 0));
@@ -566,15 +553,15 @@ export function registerAvailableRooms(server: McpServer): void {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: false,
-        openWorldHint: true,
+        openWorldHint: false,
       },
     },
-    async (args) => {
+    withToolErrorHandling(async (args) => {
       const validated = AvailableRoomsArgsSchema.parse(args);
       const result = await executeAvailableRooms(validated);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
-    }
+    })
   );
 }

--- a/src/tools/butlr-fetch-entity-details.ts
+++ b/src/tools/butlr-fetch-entity-details.ts
@@ -4,8 +4,9 @@ import { gql } from "@apollo/client";
 import { z } from "zod";
 import { detectAssetType } from "../utils/asset-helpers.js";
 import { type EntityType, ENTITY_TYPES, getValidatedFields } from "../utils/field-validator.js";
-import { createValidationError } from "../errors/mcp-errors.js";
+import { createValidationError, withToolErrorHandling } from "../errors/mcp-errors.js";
 import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
+import { debug } from "../utils/debug.js";
 import type { FetchEntityDetailsResponse, EntityResult } from "../types/responses.js";
 
 const FETCH_ENTITY_DETAILS_DESCRIPTION =
@@ -158,9 +159,7 @@ function buildQueryForFields(type: string, fields: string[]): ReturnType<typeof 
 export async function executeFetchEntityDetails(
   args: FetchEntityDetailsArgs
 ): Promise<FetchEntityDetailsResponse> {
-  if (process.env.DEBUG) {
-    console.error(`[butlr-fetch-entity-details] Fetching details for ${args.ids.length} asset(s)`);
-  }
+  debug("butlr-fetch-entity-details", `Fetching details for ${args.ids.length} asset(s)`);
 
   // Group IDs by type
   const assetsByType: Record<string, string[]> = {};
@@ -229,9 +228,7 @@ export async function executeFetchEntityDetails(
         const foundIds = new Set(dataArray.map((a: any) => a.id));
         for (const id of ids) {
           if (!foundIds.has(id)) {
-            if (process.env.DEBUG) {
-              console.error(`[butlr-fetch-entity-details] Asset not found: ${id}`);
-            }
+            debug("butlr-fetch-entity-details", `Asset not found: ${id}`);
             results.push({
               id,
               _type: type,
@@ -265,9 +262,7 @@ export async function executeFetchEntityDetails(
               _type: type,
             });
           } else {
-            if (process.env.DEBUG) {
-              console.error(`[butlr-fetch-entity-details] Asset not found: ${id}`);
-            }
+            debug("butlr-fetch-entity-details", `Asset not found: ${id}`);
             results.push({
               id,
               _type: type,
@@ -311,15 +306,15 @@ export function registerFetchEntityDetails(server: McpServer): void {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
-        openWorldHint: true,
+        openWorldHint: false,
       },
     },
-    async (args) => {
+    withToolErrorHandling(async (args) => {
       const validated = FetchEntityDetailsArgsSchema.parse(args);
       const result = await executeFetchEntityDetails(validated);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
-    }
+    })
   );
 }

--- a/src/tools/butlr-get-asset-details.ts
+++ b/src/tools/butlr-get-asset-details.ts
@@ -6,8 +6,10 @@ import {
   translateGraphQLError,
   formatMCPError,
   createValidationError,
+  withToolErrorHandling,
 } from "../errors/mcp-errors.js";
 import { detectAssetType } from "../utils/asset-helpers.js";
+import { debug } from "../utils/debug.js";
 
 const assetIdSchema = z
   .string()
@@ -340,11 +342,10 @@ export async function executeGetAssetDetails(args: GetAssetDetailsArgs) {
   const includeDevices = args.include_devices === true; // Default false
   const includeParentContext = args.include_parent_context !== false; // Default true
 
-  if (process.env.DEBUG) {
-    console.error(
-      `[get-asset-details] Fetching details for ${args.ids.length} asset(s): ${args.ids.join(", ")}`
-    );
-  }
+  debug(
+    "get-asset-details",
+    `Fetching details for ${args.ids.length} asset(s): ${args.ids.join(", ")}`
+  );
 
   const results: Array<Record<string, unknown>> = [];
 
@@ -353,9 +354,7 @@ export async function executeGetAssetDetails(args: GetAssetDetailsArgs) {
   for (const id of args.ids) {
     const type = detectAssetType(id);
     if (type === "unknown") {
-      if (process.env.DEBUG) {
-        console.error(`[get-asset-details] Warning: Unknown asset type for ID: ${id}`);
-      }
+      debug("get-asset-details", `Warning: Unknown asset type for ID: ${id}`);
       results.push({
         id,
         _type: "unknown",
@@ -403,16 +402,14 @@ export async function executeGetAssetDetails(args: GetAssetDetailsArgs) {
       const asset = data[type];
       if (asset && typeof asset === "object") {
         results.push({ ...(asset as Record<string, unknown>), _type: type });
-      } else if (process.env.DEBUG) {
-        console.error(`[get-asset-details] Asset not found: ${id}`);
+      } else {
+        debug("get-asset-details", `Asset not found: ${id}`);
       }
     } else {
       const err = outcome.reason;
       if (err && (err.graphQLErrors || err.networkError)) {
         const mcpError = translateGraphQLError(err);
-        if (process.env.DEBUG) {
-          console.error(`[get-asset-details] Error fetching ${id}:`, formatMCPError(mcpError));
-        }
+        debug("get-asset-details", `Error fetching ${id}:`, formatMCPError(mcpError));
         results.push({ id, error: formatMCPError(mcpError), _type: type });
       } else {
         throw err;
@@ -447,15 +444,15 @@ export function registerGetAssetDetails(server: McpServer): void {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
-        openWorldHint: true,
+        openWorldHint: false,
       },
     },
-    async (args) => {
+    withToolErrorHandling(async (args) => {
       const validated = GetAssetDetailsArgsSchema.parse(args);
       const result = await executeGetAssetDetails(validated);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
-    }
+    })
   );
 }

--- a/src/tools/butlr-get-current-occupancy.ts
+++ b/src/tools/butlr-get-current-occupancy.ts
@@ -10,6 +10,8 @@ import {
   getTrafficCoverageNote,
   buildRecommendation,
 } from "../utils/occupancy-helpers.js";
+import { debug } from "../utils/debug.js";
+import { withToolErrorHandling } from "../errors/mcp-errors.js";
 import type {
   CurrentOccupancyResponse,
   AssetCurrentOccupancy,
@@ -37,9 +39,7 @@ export type GetCurrentOccupancyArgs = z.output<typeof GetCurrentOccupancyArgsSch
 export async function executeGetCurrentOccupancy(
   args: GetCurrentOccupancyArgs
 ): Promise<CurrentOccupancyResponse> {
-  if (process.env.DEBUG) {
-    console.error(`[butlr-get-current-occupancy] Querying ${args.asset_ids.length} assets`);
-  }
+  debug("butlr-get-current-occupancy", `Querying ${args.asset_ids.length} assets`);
 
   // Fetch topology and sensors using shared helper
   const ctx = await fetchTopologyAndSensors();
@@ -79,7 +79,7 @@ export async function executeGetCurrentOccupancy(
           presenceHasData = true;
         }
       } catch (error: unknown) {
-        console.error(`[current-occupancy] Presence query failed:`, error);
+        debug("current-occupancy", "Presence query failed:", error);
         presenceData.warning =
           "Failed to retrieve current presence data. Occupancy value may be missing.";
       }
@@ -113,7 +113,7 @@ export async function executeGetCurrentOccupancy(
           trafficHasData = true;
         }
       } catch (error: unknown) {
-        console.error(`[current-occupancy] Traffic query failed:`, error);
+        debug("current-occupancy", "Traffic query failed:", error);
         trafficData.warning =
           "Failed to retrieve current traffic data. Occupancy value may be missing.";
       }
@@ -159,15 +159,15 @@ export function registerGetCurrentOccupancy(server: McpServer): void {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: false,
-        openWorldHint: true,
+        openWorldHint: false,
       },
     },
-    async (args) => {
+    withToolErrorHandling(async (args) => {
       const validated = GetCurrentOccupancyArgsSchema.parse(args);
       const result = await executeGetCurrentOccupancy(validated);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
-    }
+    })
   );
 }

--- a/src/tools/butlr-get-occupancy-timeseries.ts
+++ b/src/tools/butlr-get-occupancy-timeseries.ts
@@ -12,6 +12,8 @@ import {
   buildRecommendation,
 } from "../utils/occupancy-helpers.js";
 import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
+import { debug } from "../utils/debug.js";
+import { withToolErrorHandling } from "../errors/mcp-errors.js";
 import type {
   OccupancyTimeseriesResponse,
   AssetOccupancyTimeseries,
@@ -81,9 +83,7 @@ export async function executeGetOccupancyTimeseries(
   // Validate time range — let errors throw naturally
   validateTimeRange(args.interval, args.start, args.stop);
 
-  if (process.env.DEBUG) {
-    console.error(`[butlr-get-occupancy-timeseries] Querying ${args.asset_ids.length} assets`);
-  }
+  debug("butlr-get-occupancy-timeseries", `Querying ${args.asset_ids.length} assets`);
 
   // Fetch topology and sensors in parallel
   const ctx = await fetchTopologyAndSensors();
@@ -117,7 +117,7 @@ export async function executeGetOccupancyTimeseries(
           presenceData.timeseries = points;
         }
       } catch (error: unknown) {
-        console.error(`[occupancy-timeseries] Presence query failed:`, error);
+        debug("occupancy-timeseries", "Presence query failed:", error);
         presenceData.warning =
           "Failed to retrieve presence timeseries data. Results may be incomplete.";
       }
@@ -147,7 +147,7 @@ export async function executeGetOccupancyTimeseries(
           trafficData.timeseries = points;
         }
       } catch (error: unknown) {
-        console.error(`[occupancy-timeseries] Traffic query failed:`, error);
+        debug("occupancy-timeseries", "Traffic query failed:", error);
         trafficData.warning =
           "Failed to retrieve traffic timeseries data. Results may be incomplete.";
       }
@@ -197,10 +197,10 @@ export function registerGetOccupancyTimeseries(server: McpServer): void {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
-        openWorldHint: true,
+        openWorldHint: false,
       },
     },
-    async (args) => {
+    withToolErrorHandling(async (args) => {
       try {
         const validated = GetOccupancyTimeseriesArgsSchema.parse(args);
         const result = await executeGetOccupancyTimeseries(validated);
@@ -211,6 +211,6 @@ export function registerGetOccupancyTimeseries(server: McpServer): void {
         rethrowIfGraphQLError(error);
         throw error;
       }
-    }
+    })
   );
 }

--- a/src/tools/butlr-get-occupancy-timeseries.ts
+++ b/src/tools/butlr-get-occupancy-timeseries.ts
@@ -11,7 +11,6 @@ import {
   getTrafficCoverageNote,
   buildRecommendation,
 } from "../utils/occupancy-helpers.js";
-import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
 import { debug } from "../utils/debug.js";
 import { withToolErrorHandling } from "../errors/mcp-errors.js";
 import type {
@@ -201,16 +200,11 @@ export function registerGetOccupancyTimeseries(server: McpServer): void {
       },
     },
     withToolErrorHandling(async (args) => {
-      try {
-        const validated = GetOccupancyTimeseriesArgsSchema.parse(args);
-        const result = await executeGetOccupancyTimeseries(validated);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error: unknown) {
-        rethrowIfGraphQLError(error);
-        throw error;
-      }
+      const validated = GetOccupancyTimeseriesArgsSchema.parse(args);
+      const result = await executeGetOccupancyTimeseries(validated);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      };
     })
   );
 }

--- a/src/tools/butlr-hardware-snapshot.ts
+++ b/src/tools/butlr-hardware-snapshot.ts
@@ -10,6 +10,8 @@ import {
   isProductionHive,
   rethrowIfGraphQLError,
 } from "../utils/graphql-helpers.js";
+import { debug } from "../utils/debug.js";
+import { withToolErrorHandling } from "../errors/mcp-errors.js";
 import type {
   BatteryDetail,
   BatteryStatus,
@@ -243,11 +245,10 @@ interface TestDeviceCounts {
 export async function executeHardwareSnapshot(args: HardwareSnapshotArgs) {
   const scopeType = args.scope_type;
 
-  if (process.env.DEBUG) {
-    console.error(
-      `[hardware-snapshot] Querying device health for scope: ${scopeType}${args.scope_id ? `:${args.scope_id}` : ""}`
-    );
-  }
+  debug(
+    "hardware-snapshot",
+    `Querying device health for scope: ${scopeType}${args.scope_id ? `:${args.scope_id}` : ""}`
+  );
 
   let floors: Floor[] = [];
   let buildings: Building[] = [];
@@ -388,11 +389,7 @@ export async function executeHardwareSnapshot(args: HardwareSnapshotArgs) {
   const allSensors = floors.flatMap((f) => f.sensors || []);
   const allHives = floors.flatMap((f) => f.hives || []);
 
-  if (process.env.DEBUG) {
-    console.error(
-      `[hardware-snapshot] Found ${allSensors.length} sensors, ${allHives.length} hives`
-    );
-  }
+  debug("hardware-snapshot", `Found ${allSensors.length} sensors, ${allHives.length} hives`);
 
   // Calculate sensor statistics
   const sensorsOnline = allSensors.filter((s) => s.is_online).length;
@@ -648,15 +645,15 @@ export function registerHardwareSnapshot(server: McpServer): void {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: false, // Real-time data changes between calls
-        openWorldHint: true,
+        openWorldHint: false,
       },
     },
-    async (args) => {
+    withToolErrorHandling(async (args) => {
       const validated = HardwareSnapshotArgsSchema.parse(args);
       const result = await executeHardwareSnapshot(validated);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
-    }
+    })
   );
 }

--- a/src/tools/butlr-list-topology.ts
+++ b/src/tools/butlr-list-topology.ts
@@ -23,6 +23,8 @@ import {
   isProductionHive,
   rethrowIfGraphQLError,
 } from "../utils/graphql-helpers.js";
+import { debug } from "../utils/debug.js";
+import { withToolErrorHandling } from "../errors/mcp-errors.js";
 import type { ListTopologyResponse } from "../types/responses.js";
 
 const LIST_TOPOLOGY_DESCRIPTION =
@@ -71,11 +73,10 @@ export async function executeListTopology(
   const traversalDepth = args.traversal_depth ?? 0;
   const assetIds = args.asset_ids ?? [];
 
-  if (process.env.DEBUG) {
-    console.error(
-      `[butlr-list-topology] Fetching topology: starting_depth=${startingDepth}, traversal_depth=${traversalDepth}, assets=${assetIds.length || "all"}`
-    );
-  }
+  debug(
+    "butlr-list-topology",
+    `Fetching topology: starting_depth=${startingDepth}, traversal_depth=${traversalDepth}, assets=${assetIds.length || "all"}`
+  );
 
   // Use a cache key that includes devices
   const cacheKey = generateTopologyCacheKey(
@@ -91,15 +92,11 @@ export async function executeListTopology(
   const cached = getCachedTopology(cacheKey);
 
   if (cached && cached.data && cached.data.sites) {
-    if (process.env.DEBUG) {
-      console.error("[butlr-list-topology] Using cached topology");
-    }
+    debug("butlr-list-topology", "Using cached topology");
     sites = cached.data.sites as Site[];
   } else {
     // Fetch fresh topology
-    if (process.env.DEBUG) {
-      console.error("[butlr-list-topology] Fetching fresh topology");
-    }
+    debug("butlr-list-topology", "Fetching fresh topology");
 
     try {
       const result = await apolloClient.query<{ sites: SitesResponse }>({
@@ -118,16 +115,14 @@ export async function executeListTopology(
 
       // Track whether the topology data is partial (errors alongside data)
       partialData = !!result.error;
-      if (partialData && process.env.DEBUG) {
-        console.error(`[butlr-list-topology] Warning: GraphQL errors present, data may be partial`);
+      if (partialData) {
+        debug("butlr-list-topology", "Warning: GraphQL errors present, data may be partial");
       }
 
       sites = result.data.sites.data;
 
       // Query all sensors and hives separately (nested fields are broken)
-      if (process.env.DEBUG) {
-        console.error("[butlr-list-topology] Fetching all sensors and hives...");
-      }
+      debug("butlr-list-topology", "Fetching all sensors and hives...");
 
       const [sensorsResult, hivesResult] = await Promise.all([
         apolloClient.query<{ sensors: { data: Sensor[] } }>({
@@ -145,11 +140,10 @@ export async function executeListTopology(
       const allSensors = (sensorsResult.data?.sensors?.data || []).filter(isProductionSensor);
       const allHives = (hivesResult.data?.hives?.data || []).filter(isProductionHive);
 
-      if (process.env.DEBUG) {
-        console.error(
-          `[butlr-list-topology] Got ${allSensors.length} production sensors, ${allHives.length} production hives (test/placeholder devices filtered)`
-        );
-      }
+      debug(
+        "butlr-list-topology",
+        `Got ${allSensors.length} production sensors, ${allHives.length} production hives (test/placeholder devices filtered)`
+      );
 
       // Merge sensors and hives into topology by floor_id
       sites = mergeSensorsAndHivesIntoTopology(sites, allSensors, allHives);
@@ -157,12 +151,9 @@ export async function executeListTopology(
       // Only cache complete topology data — partial results should be re-fetched
       if (!partialData) {
         setCachedTopology(cacheKey, { sites });
-
-        if (process.env.DEBUG) {
-          console.error(`[butlr-list-topology] Cached topology with ${sites.length} sites`);
-        }
-      } else if (process.env.DEBUG) {
-        console.error(`[butlr-list-topology] Skipping cache — topology data is partial`);
+        debug("butlr-list-topology", `Cached topology with ${sites.length} sites`);
+      } else {
+        debug("butlr-list-topology", "Skipping cache — topology data is partial");
       }
     } catch (error: unknown) {
       rethrowIfGraphQLError(error);
@@ -309,15 +300,15 @@ export function registerListTopology(server: McpServer): void {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
-        openWorldHint: true,
+        openWorldHint: false,
       },
     },
-    async (args) => {
+    withToolErrorHandling(async (args) => {
       const validated = ListTopologyArgsSchema.parse(args);
       const result = await executeListTopology(validated);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
-    }
+    })
   );
 }

--- a/src/tools/butlr-search-assets.ts
+++ b/src/tools/butlr-search-assets.ts
@@ -12,6 +12,8 @@ import { flattenTopology, type FlattenedAsset } from "../utils/asset-flattener.j
 import { searchAssets, type SearchableAsset } from "../utils/fuzzy-match.js";
 import { buildAssetPath } from "../utils/path-builder.js";
 import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
+import { debug } from "../utils/debug.js";
+import { withToolErrorHandling } from "../errors/mcp-errors.js";
 
 const VALID_ASSET_TYPES = ["site", "building", "floor", "room", "zone", "sensor", "hive"] as const;
 
@@ -121,13 +123,12 @@ export interface SearchResult {
 export async function executeSearchAssets(args: SearchAssetsArgs) {
   const maxResults = args.max_results;
 
-  if (process.env.DEBUG) {
-    console.error(
-      `[search-assets] Searching for "${args.query}"` +
-        (args.asset_types ? ` in types: ${args.asset_types.join(",")}` : "") +
-        ` (max: ${maxResults})`
-    );
-  }
+  debug(
+    "search-assets",
+    `Searching for "${args.query}"` +
+      (args.asset_types ? ` in types: ${args.asset_types.join(",")}` : "") +
+      ` (max: ${maxResults})`
+  );
 
   // Use a generic cache key for full topology (we'll search across it)
   const cacheKey = generateTopologyCacheKey(
@@ -142,15 +143,11 @@ export async function executeSearchAssets(args: SearchAssetsArgs) {
   const cached = getCachedTopology(cacheKey);
 
   if (cached && cached.data && cached.data.sites) {
-    if (process.env.DEBUG) {
-      console.error("[search-assets] Using cached topology for search");
-    }
+    debug("search-assets", "Using cached topology for search");
     sites = cached.data.sites as Site[];
   } else {
     // Fetch fresh topology
-    if (process.env.DEBUG) {
-      console.error("[search-assets] Fetching fresh topology for search");
-    }
+    debug("search-assets", "Fetching fresh topology for search");
 
     try {
       const result = await apolloClient.query<{ sites: SitesResponse }>({
@@ -169,8 +166,8 @@ export async function executeSearchAssets(args: SearchAssetsArgs) {
 
       // Track whether the topology data is partial (errors alongside data)
       const partialData = !!result.error;
-      if (partialData && process.env.DEBUG) {
-        console.error(`[search-assets] Warning: GraphQL errors present, data may be partial`);
+      if (partialData) {
+        debug("search-assets", "Warning: GraphQL errors present, data may be partial");
       }
 
       sites = result.data.sites.data;
@@ -178,12 +175,9 @@ export async function executeSearchAssets(args: SearchAssetsArgs) {
       // Only cache complete topology data — partial results should be re-fetched
       if (!partialData) {
         setCachedTopology(cacheKey, { sites });
-
-        if (process.env.DEBUG) {
-          console.error(`[search-assets] Cached topology with ${sites.length} sites`);
-        }
-      } else if (process.env.DEBUG) {
-        console.error(`[search-assets] Skipping cache — topology data is partial`);
+        debug("search-assets", `Cached topology with ${sites.length} sites`);
+      } else {
+        debug("search-assets", "Skipping cache — topology data is partial");
       }
     } catch (error: unknown) {
       rethrowIfGraphQLError(error);
@@ -194,20 +188,17 @@ export async function executeSearchAssets(args: SearchAssetsArgs) {
   // Flatten topology into searchable list
   const flattened = flattenTopology(sites);
 
-  if (process.env.DEBUG) {
-    console.error(`[search-assets] Flattened ${flattened.length} total assets`);
-  }
+  debug("search-assets", `Flattened ${flattened.length} total assets`);
 
   // Filter by asset types if specified
   let searchableAssets = flattened;
   if (args.asset_types && args.asset_types.length > 0) {
     searchableAssets = flattened.filter((asset) => args.asset_types!.includes(asset.type));
 
-    if (process.env.DEBUG) {
-      console.error(
-        `[search-assets] Filtered to ${searchableAssets.length} assets of types: ${args.asset_types.join(",")}`
-      );
-    }
+    debug(
+      "search-assets",
+      `Filtered to ${searchableAssets.length} assets of types: ${args.asset_types.join(",")}`
+    );
   }
 
   // Perform fuzzy search
@@ -222,9 +213,7 @@ export async function executeSearchAssets(args: SearchAssetsArgs) {
     }
   );
 
-  if (process.env.DEBUG) {
-    console.error(`[search-assets] Found ${matches.length} matches`);
-  }
+  debug("search-assets", `Found ${matches.length} matches`);
 
   // Format results with minimal fields
   const results: SearchResult[] = matches.map((match) => ({
@@ -262,15 +251,15 @@ export function registerSearchAssets(server: McpServer): void {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
-        openWorldHint: true,
+        openWorldHint: false,
       },
     },
-    async (args) => {
+    withToolErrorHandling(async (args) => {
       const validated = SearchAssetsArgsSchema.parse(args);
       const result = await executeSearchAssets(validated);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
-    }
+    })
   );
 }

--- a/src/tools/butlr-space-busyness.ts
+++ b/src/tools/butlr-space-busyness.ts
@@ -15,6 +15,8 @@ import {
 } from "../utils/natural-language.js";
 import { getCachedOccupancy, setCachedOccupancy } from "../cache/occupancy-cache.js";
 import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
+import { debug } from "../utils/debug.js";
+import { withToolErrorHandling } from "../errors/mcp-errors.js";
 import type { SpaceBusynessResponse } from "../types/responses.js";
 
 /** Room with floor populated via GraphQL (includes building/site for timezone) */
@@ -144,9 +146,7 @@ export async function executeSpaceBusyness(args: SpaceBusynessArgs) {
 
   // If not an ID, search for the space
   if (!spaceId.match(/^(room|zone)_/)) {
-    if (process.env.DEBUG) {
-      console.error(`[space-busyness] Searching for space: "${args.space_id_or_name}"`);
-    }
+    debug("space-busyness", `Searching for space: "${args.space_id_or_name}"`);
 
     const searchResults = await executeSearchAssets({
       query: args.space_id_or_name,
@@ -165,9 +165,7 @@ export async function executeSpaceBusyness(args: SpaceBusynessArgs) {
     spaceId = bestMatch.id;
     spaceType = bestMatch.type as "room" | "zone";
 
-    if (process.env.DEBUG) {
-      console.error(`[space-busyness] Using best match: ${bestMatch.name} (${spaceId})`);
-    }
+    debug("space-busyness", `Using best match: ${bestMatch.name} (${spaceId})`);
   } else {
     // Determine type from ID prefix
     spaceType = spaceId.startsWith("room_") ? "room" : "zone";
@@ -224,9 +222,7 @@ export async function executeSpaceBusyness(args: SpaceBusynessArgs) {
   const cached = getCachedOccupancy(spaceId, now);
   if (cached) {
     currentOccupancy = cached.occupancy;
-    if (process.env.DEBUG) {
-      console.error(`[space-busyness] Using cached occupancy: ${currentOccupancy}`);
-    }
+    debug("space-busyness", `Using cached occupancy: ${currentOccupancy}`);
   } else {
     try {
       const occupancyData = await getCurrentOccupancy(spaceType, [spaceId]);
@@ -235,7 +231,7 @@ export async function executeSpaceBusyness(args: SpaceBusynessArgs) {
         setCachedOccupancy(spaceId, currentOccupancy, spaceType, now);
       }
     } catch (error: unknown) {
-      console.error(`[space-busyness] Failed to get occupancy:`, error);
+      debug("space-busyness", "Failed to get occupancy:", error);
       throw new Error(
         `Failed to get current occupancy for ${space.name}. The space may not have active sensors.`
       );
@@ -307,7 +303,7 @@ export async function executeSpaceBusyness(args: SpaceBusynessArgs) {
         };
       }
     } catch (error: unknown) {
-      console.error(`[space-busyness] Failed to get trend data:`, error);
+      debug("space-busyness", "Failed to get trend data:", error);
       warnings.push("Could not retrieve historical trend data. Trend comparison is unavailable.");
     }
   }
@@ -347,15 +343,15 @@ export function registerSpaceBusyness(server: McpServer): void {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: false,
-        openWorldHint: true,
+        openWorldHint: false,
       },
     },
-    async (args) => {
+    withToolErrorHandling(async (args) => {
       const validated = SpaceBusynessArgsSchema.parse(args);
       const result = await executeSpaceBusyness(validated);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
-    }
+    })
   );
 }

--- a/src/tools/butlr-traffic-flow.ts
+++ b/src/tools/butlr-traffic-flow.ts
@@ -12,8 +12,9 @@ import {
   getLocalMidnight,
 } from "../utils/timezone-helpers.js";
 import type { TimezoneMetadata } from "../utils/timezone-helpers.js";
-import { createValidationError } from "../errors/mcp-errors.js";
+import { createValidationError, withToolErrorHandling } from "../errors/mcp-errors.js";
 import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
+import { debug } from "../utils/debug.js";
 import type { TrafficFlowResponse } from "../types/responses.js";
 
 const timeStringSchema = z.string().refine(
@@ -133,9 +134,7 @@ export async function executeTrafficFlow(args: TrafficFlowArgs) {
 
   // If not an ID, search for the space
   if (!spaceId.match(/^room_/)) {
-    if (process.env.DEBUG) {
-      console.error(`[traffic-flow] Searching for space: "${args.space_id_or_name}"`);
-    }
+    debug("traffic-flow", `Searching for space: "${args.space_id_or_name}"`);
 
     const searchResults = await executeSearchAssets({
       query: args.space_id_or_name,
@@ -151,11 +150,7 @@ export async function executeTrafficFlow(args: TrafficFlowArgs) {
 
     spaceId = searchResults.matches[0].id;
 
-    if (process.env.DEBUG) {
-      console.error(
-        `[traffic-flow] Using best match: ${searchResults.matches[0].name} (${spaceId})`
-      );
-    }
+    debug("traffic-flow", `Using best match: ${searchResults.matches[0].name} (${spaceId})`);
   }
 
   // Query room details, topology for timezone, and all sensors
@@ -217,9 +212,7 @@ export async function executeTrafficFlow(args: TrafficFlowArgs) {
       );
     }
 
-    if (process.env.DEBUG) {
-      console.error(`[traffic-flow] Found ${trafficSensors.length} traffic sensors for room`);
-    }
+    debug("traffic-flow", `Found ${trafficSensors.length} traffic sensors for room`);
   } catch (error: unknown) {
     rethrowIfGraphQLError(error);
     throw error;
@@ -269,16 +262,13 @@ export async function executeTrafficFlow(args: TrafficFlowArgs) {
       ? "today (UTC fallback)"
       : `today (${tzMetadata.timezone_abbr})`;
 
-    if (process.env.DEBUG) {
-      console.error(
-        `[traffic-flow] Today starts at ${start} (midnight ${usedUtcFallback ? "UTC fallback" : tzMetadata.timezone_abbr})`
-      );
-    }
+    debug(
+      "traffic-flow",
+      `Today starts at ${start} (midnight ${usedUtcFallback ? "UTC fallback" : tzMetadata.timezone_abbr})`
+    );
   }
 
-  if (process.env.DEBUG) {
-    console.error(`[traffic-flow] Querying traffic from ${start} to ${stop}`);
-  }
+  debug("traffic-flow", `Querying traffic from ${start} to ${stop}`);
 
   // Query traffic data with timezone
   interface TrafficDataPoint {
@@ -306,16 +296,13 @@ export async function executeTrafficFlow(args: TrafficFlowArgs) {
 
     trafficData = response.data as TrafficDataPoint[];
 
-    if (process.env.DEBUG) {
-      console.error(
-        `[traffic-flow] Received ${trafficData.length} data points from ${trafficSensors.length} sensors`
-      );
-    }
+    debug(
+      "traffic-flow",
+      `Received ${trafficData.length} data points from ${trafficSensors.length} sensors`
+    );
   } catch (error: unknown) {
     rethrowIfGraphQLError(error);
-    if (process.env.DEBUG) {
-      console.error(`[traffic-flow] Failed to get traffic data:`, error);
-    }
+    debug("traffic-flow", "Failed to get traffic data:", error);
     const msg = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to get traffic data for ${room.name}. ${msg}`);
   }
@@ -439,15 +426,15 @@ export function registerTrafficFlow(server: McpServer): void {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: false,
-        openWorldHint: true,
+        openWorldHint: false,
       },
     },
-    async (args) => {
+    withToolErrorHandling(async (args) => {
       const validated = TrafficFlowArgsSchema.parse(args);
       const result = await executeTrafficFlow(validated);
       return {
         content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
       };
-    }
+    })
   );
 }

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,0 +1,9 @@
+/**
+ * Centralized debug logger. Writes to stderr (required for MCP stdio transport).
+ * Only logs when DEBUG=butlr-mcp or DEBUG=*.
+ */
+export function debug(tag: string, ...args: unknown[]): void {
+  if (process.env.DEBUG === "butlr-mcp" || process.env.DEBUG === "*") {
+    console.error(`[${tag}]`, ...args);
+  }
+}

--- a/src/utils/timezone-helpers.ts
+++ b/src/utils/timezone-helpers.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Site, Building, Floor } from "../clients/types.js";
+import { debug } from "./debug.js";
 
 /**
  * Get the site timezone for any asset (floor, room, zone)
@@ -69,9 +70,7 @@ export function getTimezoneAbbreviation(timezone: string, date: Date = new Date(
     const tzPart = parts.find((p) => p.type === "timeZoneName");
     return tzPart?.value || "UTC";
   } catch (error) {
-    if (process.env.DEBUG) {
-      console.error(`[timezone-helpers] Failed to get abbreviation for ${timezone}:`, error);
-    }
+    debug("timezone-helpers", `Failed to get abbreviation for ${timezone}:`, error);
     return "UTC";
   }
 }
@@ -97,9 +96,7 @@ export function getUTCOffset(timezone: string, date: Date = new Date()): string 
 
     return "UTC";
   } catch (error) {
-    if (process.env.DEBUG) {
-      console.error(`[timezone-helpers] Failed to get offset for ${timezone}:`, error);
-    }
+    debug("timezone-helpers", `Failed to get offset for ${timezone}:`, error);
     return "UTC";
   }
 }
@@ -152,9 +149,7 @@ export function getCurrentLocalTime(timezone: string): string {
 
     return `${dateStr} ${tzAbbr}`;
   } catch (error) {
-    if (process.env.DEBUG) {
-      console.error(`[timezone-helpers] Failed to format time for ${timezone}:`, error);
-    }
+    debug("timezone-helpers", `Failed to format time for ${timezone}:`, error);
     return new Date().toISOString();
   }
 }
@@ -214,7 +209,7 @@ export function getLocalMidnight(date: Date, timezone: string): Date {
 
     return estimate;
   } catch (error) {
-    console.error(`[timezone] Failed to calculate local midnight for ${timezone}:`, error);
+    debug("timezone-helpers", `Failed to calculate local midnight for ${timezone}:`, error);
     // Fallback to UTC midnight
     const utcMidnight = new Date(date);
     utcMidnight.setUTCHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary

Addresses findings from an adversarial review ahead of making the repository public. Changes focus on MCP spec compliance, debug logging consistency, CI hardening, and contributor infrastructure.

- **MCP spec compliance**: Add `isError: true` to tool error responses via `withToolErrorHandling()` wrapper, so LLMs can see and recover from errors. Set `openWorldHint: false` on all tools (closed system).
- **Debug logging**: Centralized `debug()` utility replaces inconsistent `process.env.DEBUG` checks across ~25 files. Only `DEBUG=butlr-mcp` or `DEBUG=*` triggers output; stderr is quiet otherwise.
- **Dynamic version**: Server version read from `package.json` at startup instead of hardcoded string.
- **CI matrix**: Test on Node 18, 20, and 22 to validate the `>=18.0.0` engine requirement.
- **Stale docs fixed**: Removed hardcoded test count from CONTRIBUTING.md, marked `BUTLR_ORG_ID` as optional in CLAUDE.md and .env.example, updated LICENSE copyright to 2025-2026.
- **Contributor infrastructure**: Added GitHub issue templates (bug report, feature request), PR template, and CODEOWNERS file.
- **Branch cleanup**: Pruned 11 stale remote branches.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — all 442 tests pass
- [x] `npm run lint` — 0 errors (9 pre-existing warnings)
- [x] `npm run build` succeeds
- [x] Pre-commit hooks pass (typecheck, tests, secret scan, lint-staged)
- [ ] Verify CI runs on Node 18, 20, and 22 matrix
- [ ] Verify `DEBUG=butlr-mcp npm run dev` shows debug output, plain `npm run dev` is quiet