### PR TITLE
Release v0.1.2: OIDC trusted publishing with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ jobs:
   publish:
     name: Build & Publish
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
@@ -32,6 +33,4 @@ jobs:
         run: npm run build
 
       - name: Publish
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-04-14
+
+### Changed
+- Switch npm publish to OIDC trusted publishing — removes NPM_TOKEN secret in favor of GitHub Actions identity verification
+- Re-enable `--provenance` flag for cryptographic build attestation now that the repo is public
+- Add `npm-publish` GitHub environment with team reviewer gate for deployment protection
+
+### Improved
+- Add "When NOT to Use" negative guidance to all 10 tool descriptions for better LLM tool routing
+- Replace non-null assertions (`!`) with safe type narrowing via local variables in tool code
+
 ## [0.1.1] - 2026-03-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@butlr/butlr-mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Model Context Protocol server providing secure, read-only access to Butlr occupancy and asset data",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Switch npm publish from `NPM_TOKEN` secret to GitHub Actions OIDC trusted publishing
- Re-enable `--provenance` flag for cryptographic build attestation (removed in #12 when repo was private)
- Add `npm-publish` GitHub environment with `butlrtechnologies/backend` reviewer gate
- Bump version to 0.1.2, update changelog incorporating merged #16 and #22

## Setup completed (outside this PR)

- [x] Trusted publisher configured on npmjs.com → `butlrtechnologies/butlr-mcp` + `publish.yml` + `npm-publish`
- [x] `npm-publish` environment created in GitHub with reviewer gate and `v*` tag rule

## Test plan

- [ ] Merge this PR
- [ ] Tag and push: `git tag v0.1.2 && git push origin v0.1.2`
- [ ] Verify publish workflow triggers and requests reviewer approval
- [ ] Verify package publishes to npm with provenance badge
- [ ] Delete `NPM_TOKEN` secret from GitHub repo settings