### PR TITLE
Fix OIDC trusted publishing: upgrade to actions v6 and Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -33,4 +33,4 @@ jobs:
         run: npm run build
 
       - name: Publish
-        run: npm publish --provenance
+        run: npm publish


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` and `actions/setup-node` from v4 to v6 (v4 deprecated for Node 20)
- Use Node 24 for publish workflow (npm CLI OIDC auto-detection requires newer npm)
- Drop explicit `--provenance` flag — trusted publishing generates provenance automatically
- Add Node 24 to CI test matrix

## Why

The v0.1.2 publish failed with E404 because the npm CLI on Node 20 doesn't support OIDC token auto-detection for trusted publishing. The newer npm CLI shipped with Node 24 handles the OIDC exchange transparently.

## Test plan

- [ ] Merge this PR
- [ ] Delete and retag `v0.1.2`: `git tag -d v0.1.2 && git push origin :refs/tags/v0.1.2`
- [ ] Retag on latest main and push
- [ ] Verify publish completes successfully with OIDC