### PR TITLE
feat: add butlr_list_tags tool and fix available_rooms tag filter (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-04-26
+
+### Added
+- `butlr_list_tags` — discover the tag vocabulary in an org with per-level usage counts (`applied_to: { rooms, zones, floors }`). Supports `name_contains` substring filter and `min_usage` threshold. Tags are sorted by total usage descending. (Spot-level tags exist in the data model but are not yet surfaced.)
+
+### Fixed
+- `butlr_available_rooms` tag filter — the `roomsByTag` query was sending tag names as `tags`, but the API requires tag IDs as `tagIDs`. The tool now resolves tag names to IDs (case-insensitive) via the `tags` query before calling `roomsByTag(tagIDs:)`. Unknown tag names produce a clear warning pointing users to `butlr_list_tags`. The `roomsByTag` response is now correctly unwrapped from its `Rooms.data` wrapper.
+
+### Changed
+- `butlr_available_rooms` accepts a new `tag_match` arg (`"all"` default, or `"any"`) controlling multi-tag semantics. Maps to the GraphQL `useOR` parameter.
+
 ## [0.1.2] - 2026-04-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-## [0.1.3] - 2026-04-26
+## [0.2.0] - 2026-04-26
 
 ### Added
 - `butlr_list_tags` — discover the tag vocabulary in an org with per-level usage counts (`applied_to: { rooms, zones, floors }`). Supports `name_contains` substring filter and `min_usage` threshold. Tags are sorted by total usage descending. (Spot-level tags exist in the data model but are not yet surfaced.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [0.2.0] - 2026-04-26
 
 ### Added
-- `butlr_list_tags` — discover the tag vocabulary in an org with per-level usage counts (`applied_to: { rooms, zones, floors }`). Supports `name_contains` substring filter and `min_usage` threshold. Tags are sorted by total usage descending. (Spot-level tags exist in the data model but are not yet surfaced.)
+- `butlr_list_tags` — discover the tag vocabulary in an org with per-level usage counts (`applied_to: { rooms, zones, floors }`). Supports `name_contains` substring filter and `min_usage` threshold. Tags are sorted by total usage descending. (Spot-level tags exist in the data model but are not surfaced by this tool.)
+- `butlr_available_rooms` response now includes a structured `unknown_tags` field listing any supplied tag names that did not resolve, so consumers can react programmatically without parsing the prose `warning`.
 
 ### Fixed
-- `butlr_available_rooms` tag filter — the `roomsByTag` query was sending tag names as `tags`, but the API requires tag IDs as `tagIDs`. The tool now resolves tag names to IDs (case-insensitive) via the `tags` query before calling `roomsByTag(tagIDs:)`. Unknown tag names produce a clear warning pointing users to `butlr_list_tags`. The `roomsByTag` response is now correctly unwrapped from its `Rooms.data` wrapper.
+- `butlr_available_rooms` tag filter — the `roomsByTag` query was sending tag names as `tags`, but the API requires tag IDs as `tagIDs`. The tool now resolves tag names to IDs (case-insensitive) via the `tags` query before calling `roomsByTag(tagIDs:)`. The `roomsByTag` response is now correctly unwrapped from its `data` wrapper.
+- `butlr_available_rooms` no longer silently relaxes AND semantics when one of the supplied tag names is unknown. Under `tag_match='all'` (the default), an unresolved tag short-circuits to an empty result with a clear error; only `tag_match='any'` continues with the resolved subset and a soft warning.
+- Backend GraphQL errors returned via Apollo's `errorPolicy:'all'` are now surfaced as MCP `AUTH_EXPIRED` / `RATE_LIMITED` / `INTERNAL_ERROR` errors instead of being silently coerced into empty result sets.
+- Unexpected response shapes from `roomsByTag` and `sites` queries now raise an MCP `INTERNAL_ERROR` (retryable) instead of a generic `Error`.
 
 ### Changed
 - `butlr_available_rooms` accepts a new `tag_match` arg (`"all"` default, or `"any"`) controlling multi-tag semantics. Maps to the GraphQL `useOR` parameter.
+- Introduced branded `TagId` / `TagName` types at the tag-resolution boundary so the API's name-vs-id distinction is enforced at compile time.
 
 ## [0.1.2] - 2026-04-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@butlr/butlr-mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@butlr/butlr-mcp-server",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^4.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@butlr/butlr-mcp-server",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@butlr/butlr-mcp-server",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@butlr/butlr-mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Model Context Protocol server providing secure, read-only access to Butlr occupancy and asset data",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@butlr/butlr-mcp-server",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Model Context Protocol server providing secure, read-only access to Butlr occupancy and asset data",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__fixtures__/graphql/tags-list.json
+++ b/src/__fixtures__/graphql/tags-list.json
@@ -1,0 +1,65 @@
+{
+  "tags": [
+    {
+      "__typename": "Tag",
+      "id": "tag_000001",
+      "name": "bsc",
+      "organization_id": "org_000001",
+      "rooms": [],
+      "zones": [
+        { "__typename": "Zone", "id": "zone_000001" },
+        { "__typename": "Zone", "id": "zone_000002" },
+        { "__typename": "Zone", "id": "zone_000003" }
+      ],
+      "floors": []
+    },
+    {
+      "__typename": "Tag",
+      "id": "tag_000002",
+      "name": "4ft",
+      "organization_id": "org_000001",
+      "rooms": [],
+      "zones": [
+        { "__typename": "Zone", "id": "zone_000001" },
+        { "__typename": "Zone", "id": "zone_000004" }
+      ],
+      "floors": []
+    },
+    {
+      "__typename": "Tag",
+      "id": "tag_000003",
+      "name": "lab",
+      "organization_id": "org_000001",
+      "rooms": [
+        { "__typename": "Room", "id": "room_000001" },
+        { "__typename": "Room", "id": "room_000002" }
+      ],
+      "zones": [
+        { "__typename": "Zone", "id": "zone_000005" }
+      ],
+      "floors": [
+        { "__typename": "Floor", "id": "space_000001" }
+      ]
+    },
+    {
+      "__typename": "Tag",
+      "id": "tag_000004",
+      "name": "unused-tag",
+      "organization_id": "org_000001",
+      "rooms": [],
+      "zones": [],
+      "floors": []
+    },
+    {
+      "__typename": "Tag",
+      "id": "tag_000005",
+      "name": "BSC-equip",
+      "organization_id": "org_000001",
+      "rooms": [],
+      "zones": [
+        { "__typename": "Zone", "id": "zone_000006" }
+      ],
+      "floors": []
+    }
+  ]
+}

--- a/src/__fixtures__/graphql/tags-list.json
+++ b/src/__fixtures__/graphql/tags-list.json
@@ -3,7 +3,7 @@
     {
       "__typename": "Tag",
       "id": "tag_000001",
-      "name": "bsc",
+      "name": "videoconf",
       "organization_id": "org_000001",
       "rooms": [],
       "zones": [
@@ -16,7 +16,7 @@
     {
       "__typename": "Tag",
       "id": "tag_000002",
-      "name": "4ft",
+      "name": "focus",
       "organization_id": "org_000001",
       "rooms": [],
       "zones": [
@@ -28,7 +28,7 @@
     {
       "__typename": "Tag",
       "id": "tag_000003",
-      "name": "lab",
+      "name": "huddle",
       "organization_id": "org_000001",
       "rooms": [
         { "__typename": "Room", "id": "room_000001" },
@@ -53,7 +53,7 @@
     {
       "__typename": "Tag",
       "id": "tag_000005",
-      "name": "BSC-equip",
+      "name": "videoconf-large",
       "organization_id": "org_000001",
       "rooms": [],
       "zones": [

--- a/src/clients/queries/tags.ts
+++ b/src/clients/queries/tags.ts
@@ -9,6 +9,21 @@ import { gql } from "@apollo/client";
  */
 
 /**
+ * Branded string types for tag identifiers.
+ *
+ * The Butlr API filter `roomsByTag` accepts tag *IDs*, not tag *names*.
+ * These two are both `string` at runtime, which previously led to silent
+ * filter failures when names were sent in the IDs slot. Branding them keeps
+ * the distinction visible at the type level so the wrong one cannot be
+ * passed by accident.
+ */
+export type TagId = string & { readonly __brand: "TagId" };
+export type TagName = string & { readonly __brand: "TagName" };
+
+export const asTagId = (value: string): TagId => value as TagId;
+export const asTagName = (value: string): TagName => value as TagName;
+
+/**
  * List every tag in the org along with its application footprint.
  *
  * Each tag's `rooms`, `zones`, and `floors` arrays are returned with

--- a/src/clients/queries/tags.ts
+++ b/src/clients/queries/tags.ts
@@ -1,0 +1,49 @@
+import { gql } from "@apollo/client";
+
+/**
+ * GraphQL queries for tag retrieval and lookups.
+ *
+ * Tags are org-scoped: a single tag (id, name, organization_id) can be
+ * applied to any combination of rooms, zones, and floors via separate
+ * association tables. There is no per-level tag namespace.
+ */
+
+/**
+ * List every tag in the org along with its application footprint.
+ *
+ * Each tag's `rooms`, `zones`, and `floors` arrays are returned with
+ * id-only payloads so the response stays bounded by tag count.
+ */
+export const GET_TAGS_WITH_USAGE = gql`
+  query GetTagsWithUsage {
+    tags {
+      id
+      name
+      organization_id
+      rooms {
+        id
+      }
+      zones {
+        id
+      }
+      floors {
+        id
+      }
+    }
+  }
+`;
+
+/**
+ * Minimal tag listing — id and name only.
+ *
+ * Used to resolve user-supplied tag names to tag IDs before invoking
+ * tag-filtered queries (e.g. `roomsByTag(tagIDs:..)`).
+ */
+export const GET_TAGS_MINIMAL = gql`
+  query GetTagsMinimal {
+    tags {
+      id
+      name
+    }
+  }
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { registerListTopology } from "./tools/butlr-list-topology.js";
 import { registerFetchEntityDetails } from "./tools/butlr-fetch-entity-details.js";
 import { registerGetOccupancyTimeseries } from "./tools/butlr-get-occupancy-timeseries.js";
 import { registerGetCurrentOccupancy } from "./tools/butlr-get-current-occupancy.js";
+import { registerListTags } from "./tools/butlr-list-tags.js";
 import { debug } from "./utils/debug.js";
 
 const require = createRequire(import.meta.url);
@@ -35,6 +36,7 @@ registerListTopology(server);
 registerFetchEntityDetails(server);
 registerGetOccupancyTimeseries(server);
 registerGetCurrentOccupancy(server);
+registerListTags(server);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/tools/__tests__/integration/butlr-available-rooms.integration.test.ts
+++ b/src/tools/__tests__/integration/butlr-available-rooms.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { executeAvailableRooms } from "../../butlr-available-rooms.js";
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+import { executeAvailableRooms, GET_ROOMS_BY_TAG } from "../../butlr-available-rooms.js";
 import { apolloClient } from "../../../clients/graphql-client.js";
 import * as reportingClient from "../../../clients/reporting-client.js";
 import { loadGraphQLFixture } from "../../../__mocks__/apollo-client.js";
@@ -115,72 +116,82 @@ describe("butlr_available_rooms - Integration", () => {
   });
 
   describe("Capacity filtering", () => {
-    it("filters by min_capacity", async () => {
-      const fixture = loadGraphQLFixture("full-topology-org");
+    // Reference rooms in full-topology-org.json with known capacity:
+    //   room_000084 -> capacity.max = 1
+    //   room_000095 -> capacity.max = 6
+    //   room_000099 -> capacity.max = 10
+    //   room_000106 -> capacity.max = 20
+    const FOCUS_ROOM_IDS = ["room_000084", "room_000095", "room_000099", "room_000106"];
 
+    function mockAllZeroOccupancy(roomIds: string[]) {
+      vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue(
+        roomIds.map((id) => ({
+          start: "2025-10-13T00:00:00Z",
+          measurement: "room_occupancy",
+          value: 0,
+          asset_id: id,
+        }))
+      );
+    }
+
+    it("excludes rooms below min_capacity and includes those at/above it", async () => {
+      const fixture = loadGraphQLFixture("full-topology-org");
       vi.mocked(apolloClient.query).mockResolvedValue({
         data: fixture,
         loading: false,
         networkStatus: 7,
       } as any);
-
-      // Mock occupancy
-      vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
+      mockAllZeroOccupancy(FOCUS_ROOM_IDS);
 
       const result = await executeAvailableRooms({ min_capacity: 10 });
 
-      // All returned rooms should have capacity >= 10
-      result.available_rooms.forEach((room) => {
-        if (room.capacity?.max) {
-          expect(room.capacity.max).toBeGreaterThanOrEqual(10);
-        }
+      const ids = result.available_rooms.map((r) => r.id);
+      expect(ids).toContain("room_000099"); // cap=10
+      expect(ids).toContain("room_000106"); // cap=20
+      expect(ids).not.toContain("room_000084"); // cap=1
+      expect(ids).not.toContain("room_000095"); // cap=6
+      result.available_rooms.forEach((r) => {
+        expect(r.capacity?.max ?? 0).toBeGreaterThanOrEqual(10);
       });
     });
 
-    it("filters by max_capacity", async () => {
+    it("excludes rooms above max_capacity and includes those at/below it", async () => {
       const fixture = loadGraphQLFixture("full-topology-org");
-
       vi.mocked(apolloClient.query).mockResolvedValue({
         data: fixture,
         loading: false,
         networkStatus: 7,
       } as any);
+      mockAllZeroOccupancy(FOCUS_ROOM_IDS);
 
-      vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
+      const result = await executeAvailableRooms({ max_capacity: 15 });
 
-      const result = await executeAvailableRooms({ max_capacity: 20 });
-
-      // All returned rooms should have capacity <= 20
-      result.available_rooms.forEach((room) => {
-        if (room.capacity?.max) {
-          expect(room.capacity.max).toBeLessThanOrEqual(20);
-        }
+      const ids = result.available_rooms.map((r) => r.id);
+      expect(ids).toContain("room_000084"); // cap=1
+      expect(ids).toContain("room_000095"); // cap=6
+      expect(ids).toContain("room_000099"); // cap=10
+      expect(ids).not.toContain("room_000106"); // cap=20
+      result.available_rooms.forEach((r) => {
+        expect(r.capacity?.max ?? 0).toBeLessThanOrEqual(15);
       });
     });
 
-    it("filters by both min and max capacity", async () => {
+    it("filters by both min and max capacity (inclusive bounds)", async () => {
       const fixture = loadGraphQLFixture("full-topology-org");
-
       vi.mocked(apolloClient.query).mockResolvedValue({
         data: fixture,
         loading: false,
         networkStatus: 7,
       } as any);
+      mockAllZeroOccupancy(FOCUS_ROOM_IDS);
 
-      vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
+      const result = await executeAvailableRooms({ min_capacity: 6, max_capacity: 10 });
 
-      const result = await executeAvailableRooms({
-        min_capacity: 4,
-        max_capacity: 12,
-      });
-
-      // All returned rooms should be in range
-      result.available_rooms.forEach((room) => {
-        if (room.capacity?.max) {
-          expect(room.capacity.max).toBeGreaterThanOrEqual(4);
-          expect(room.capacity.max).toBeLessThanOrEqual(12);
-        }
-      });
+      const ids = result.available_rooms.map((r) => r.id);
+      expect(ids).toContain("room_000095"); // cap=6 (lower bound)
+      expect(ids).toContain("room_000099"); // cap=10 (upper bound)
+      expect(ids).not.toContain("room_000084"); // cap=1
+      expect(ids).not.toContain("room_000106"); // cap=20
     });
   });
 
@@ -285,9 +296,9 @@ describe("butlr_available_rooms - Integration", () => {
   describe("Tag filtering", () => {
     const tagsResponse = {
       tags: [
-        { id: "tag_000001", name: "bsc" },
-        { id: "tag_000002", name: "4ft" },
-        { id: "tag_000003", name: "lab" },
+        { id: "tag_000001", name: "videoconf" },
+        { id: "tag_000002", name: "focus" },
+        { id: "tag_000003", name: "huddle" },
       ],
     };
 
@@ -344,10 +355,11 @@ describe("butlr_available_rooms - Integration", () => {
         },
       ]);
 
-      const result = await executeAvailableRooms({ tags: ["4ft", "bsc"] });
+      const result = await executeAvailableRooms({ tags: ["focus", "videoconf"] });
 
       expect(apolloClient.query).toHaveBeenCalledTimes(2);
       const roomsCall = vi.mocked(apolloClient.query).mock.calls[1][0];
+      expect(roomsCall.query).toBe(GET_ROOMS_BY_TAG);
       expect(roomsCall.variables).toEqual({
         tagIDs: ["tag_000002", "tag_000001"],
         useOR: false,
@@ -372,7 +384,7 @@ describe("butlr_available_rooms - Integration", () => {
 
       vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
 
-      await executeAvailableRooms({ tags: ["bsc"], tag_match: "any" });
+      await executeAvailableRooms({ tags: ["videoconf"], tag_match: "any" });
 
       const roomsCall = vi.mocked(apolloClient.query).mock.calls[1][0];
       expect(roomsCall.variables).toEqual({
@@ -396,7 +408,7 @@ describe("butlr_available_rooms - Integration", () => {
 
       vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
 
-      await executeAvailableRooms({ tags: ["bsc"], tag_match: "all" });
+      await executeAvailableRooms({ tags: ["videoconf"], tag_match: "all" });
 
       const roomsCall = vi.mocked(apolloClient.query).mock.calls[1][0];
       expect(roomsCall.variables).toEqual({
@@ -420,7 +432,7 @@ describe("butlr_available_rooms - Integration", () => {
 
       vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
 
-      await executeAvailableRooms({ tags: ["BSC", "LAB"] });
+      await executeAvailableRooms({ tags: ["VIDEOCONF", "HUDDLE"] });
 
       const roomsCall = vi.mocked(apolloClient.query).mock.calls[1][0];
       expect(roomsCall.variables.tagIDs.sort()).toEqual(["tag_000001", "tag_000003"].sort());
@@ -440,9 +452,36 @@ describe("butlr_available_rooms - Integration", () => {
       expect(result.available_rooms).toEqual([]);
       expect(result.warning).toMatch(/no matching tags/i);
       expect(result.warning).toMatch(/butlr_list_tags/i);
+      expect(result.unknown_tags).toEqual(["does-not-exist"]);
     });
 
-    it("includes a warning listing unknown tags when some but not all tags resolve", async () => {
+    it("under tag_match='all' (default), partial resolution short-circuits without querying roomsByTag", async () => {
+      // C1 regression: under AND semantics, an unresolved tag means the
+      // query is unsatisfiable. We must NOT silently relax to the resolved
+      // subset (which would return a strictly broader result).
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: tagsResponse,
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeAvailableRooms({
+        tags: ["videoconf", "does-not-exist"],
+      });
+
+      // Only the tag-resolution query should have run; roomsByTag must NOT.
+      expect(apolloClient.query).toHaveBeenCalledTimes(1);
+      expect(reportingClient.getCurrentOccupancy).not.toHaveBeenCalled();
+
+      expect(result.total_available).toBe(0);
+      expect(result.available_rooms).toEqual([]);
+      expect(result.warning).toMatch(/cannot satisfy tag_match='all'/i);
+      expect(result.warning).toMatch(/does-not-exist/);
+      expect(result.warning).toMatch(/butlr_list_tags/i);
+      expect(result.unknown_tags).toEqual(["does-not-exist"]);
+    });
+
+    it("under tag_match='any', partial resolution surfaces structured unknown_tags + soft warning and queries with the resolved subset", async () => {
       vi.mocked(apolloClient.query)
         .mockResolvedValueOnce({
           data: tagsResponse,
@@ -458,13 +497,16 @@ describe("butlr_available_rooms - Integration", () => {
       vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
 
       const result = await executeAvailableRooms({
-        tags: ["bsc", "does-not-exist", "also-missing"],
+        tags: ["videoconf", "does-not-exist", "also-missing"],
+        tag_match: "any",
       });
 
       const roomsCall = vi.mocked(apolloClient.query).mock.calls[1][0];
-      expect(roomsCall.variables.tagIDs).toEqual(["tag_000001"]);
+      expect(roomsCall.query).toBe(GET_ROOMS_BY_TAG);
+      expect(roomsCall.variables).toEqual({ tagIDs: ["tag_000001"], useOR: true });
       expect(result.warning).toMatch(/does-not-exist/);
       expect(result.warning).toMatch(/also-missing/);
+      expect(result.unknown_tags).toEqual(["does-not-exist", "also-missing"]);
     });
 
     it("unwraps roomsByTag.data correctly (regression: previously treated as array)", async () => {
@@ -504,13 +546,57 @@ describe("butlr_available_rooms - Integration", () => {
         },
       ]);
 
-      const result = await executeAvailableRooms({ tags: ["bsc"] });
+      const result = await executeAvailableRooms({ tags: ["videoconf"] });
 
       expect(result.total_available).toBe(2);
       expect(result.available_rooms.map((r) => r.id).sort()).toEqual([
         "room_000001",
         "room_000002",
       ]);
+    });
+
+    it("throws a translated MCP error when roomsByTag returns the legacy array shape (regression for the original bug)", async () => {
+      // Pre-fix code accepted an array; the fixed code expects { data: [...] }.
+      // Mock the legacy shape and assert we now fail loud rather than crash on
+      // an unexpected access pattern.
+      vi.mocked(apolloClient.query)
+        .mockResolvedValueOnce({
+          data: tagsResponse,
+          loading: false,
+          networkStatus: 7,
+        } as never)
+        .mockResolvedValueOnce({
+          data: { roomsByTag: [] },
+          loading: false,
+          networkStatus: 7,
+        } as never);
+
+      await expect(executeAvailableRooms({ tags: ["videoconf"] })).rejects.toThrow(
+        /\[INTERNAL_ERROR\].*missing data envelope/i
+      );
+    });
+
+    it("translates a CombinedGraphQLErrors result.error into an MCP error (regression for errorPolicy:'all' silent failure)", async () => {
+      // Apollo Client 4.x with errorPolicy:'all' resolves with `result.error`
+      // populated, NOT a rejected promise. Without explicit handling, the tool
+      // would coerce data:null → [] and silently report "no tags found".
+      const combined = new CombinedGraphQLErrors(
+        { data: { tags: null }, errors: [{ message: "Forbidden" }] },
+        [{ message: "Forbidden", extensions: { code: "UNAUTHENTICATED" } }]
+      );
+
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: { tags: null },
+        error: combined,
+        loading: false,
+        networkStatus: 8,
+      } as never);
+
+      await expect(executeAvailableRooms({ tags: ["videoconf"] })).rejects.toThrow(
+        /\[AUTH_EXPIRED\]/
+      );
+      // roomsByTag must not have been called.
+      expect(apolloClient.query).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/tools/__tests__/integration/butlr-available-rooms.integration.test.ts
+++ b/src/tools/__tests__/integration/butlr-available-rooms.integration.test.ts
@@ -282,6 +282,238 @@ describe("butlr_available_rooms - Integration", () => {
     });
   });
 
+  describe("Tag filtering", () => {
+    const tagsResponse = {
+      tags: [
+        { id: "tag_000001", name: "bsc" },
+        { id: "tag_000002", name: "4ft" },
+        { id: "tag_000003", name: "lab" },
+      ],
+    };
+
+    function buildRoomsByTagResponse(roomIds: string[]) {
+      return {
+        roomsByTag: {
+          data: roomIds.map((id, i) => ({
+            __typename: "Room",
+            id,
+            name: `Tagged Room ${i + 1}`,
+            floorID: "space_000001",
+            roomType: null,
+            customID: null,
+            capacity: { __typename: "Capacity", max: 6, mid: 4 },
+            area: null,
+            coordinates: null,
+            floor: {
+              __typename: "Floor",
+              id: "space_000001",
+              name: "Floor 1",
+              building_id: "building_000001",
+              building: {
+                __typename: "Building",
+                id: "building_000001",
+                name: "Main Building",
+                site_id: "site_000001",
+              },
+            },
+          })),
+        },
+      };
+    }
+
+    it("resolves tag names to IDs and calls roomsByTag with tagIDs (AND semantics by default)", async () => {
+      vi.mocked(apolloClient.query)
+        .mockResolvedValueOnce({
+          data: tagsResponse,
+          loading: false,
+          networkStatus: 7,
+        } as never)
+        .mockResolvedValueOnce({
+          data: buildRoomsByTagResponse(["room_000001"]),
+          loading: false,
+          networkStatus: 7,
+        } as never);
+
+      vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([
+        {
+          start: "2025-10-13T00:00:00Z",
+          measurement: "room_occupancy",
+          value: 0,
+          asset_id: "room_000001",
+          asset_name: "Tagged Room 1",
+        },
+      ]);
+
+      const result = await executeAvailableRooms({ tags: ["4ft", "bsc"] });
+
+      expect(apolloClient.query).toHaveBeenCalledTimes(2);
+      const roomsCall = vi.mocked(apolloClient.query).mock.calls[1][0];
+      expect(roomsCall.variables).toEqual({
+        tagIDs: ["tag_000002", "tag_000001"],
+        useOR: false,
+      });
+
+      expect(result.total_available).toBe(1);
+      expect(result.available_rooms[0].id).toBe("room_000001");
+    });
+
+    it("uses useOR=true when tag_match='any'", async () => {
+      vi.mocked(apolloClient.query)
+        .mockResolvedValueOnce({
+          data: tagsResponse,
+          loading: false,
+          networkStatus: 7,
+        } as never)
+        .mockResolvedValueOnce({
+          data: buildRoomsByTagResponse(["room_000001", "room_000002"]),
+          loading: false,
+          networkStatus: 7,
+        } as never);
+
+      vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
+
+      await executeAvailableRooms({ tags: ["bsc"], tag_match: "any" });
+
+      const roomsCall = vi.mocked(apolloClient.query).mock.calls[1][0];
+      expect(roomsCall.variables).toEqual({
+        tagIDs: ["tag_000001"],
+        useOR: true,
+      });
+    });
+
+    it("uses useOR=false when tag_match='all' is explicit", async () => {
+      vi.mocked(apolloClient.query)
+        .mockResolvedValueOnce({
+          data: tagsResponse,
+          loading: false,
+          networkStatus: 7,
+        } as never)
+        .mockResolvedValueOnce({
+          data: buildRoomsByTagResponse([]),
+          loading: false,
+          networkStatus: 7,
+        } as never);
+
+      vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
+
+      await executeAvailableRooms({ tags: ["bsc"], tag_match: "all" });
+
+      const roomsCall = vi.mocked(apolloClient.query).mock.calls[1][0];
+      expect(roomsCall.variables).toEqual({
+        tagIDs: ["tag_000001"],
+        useOR: false,
+      });
+    });
+
+    it("matches tag names case-insensitively", async () => {
+      vi.mocked(apolloClient.query)
+        .mockResolvedValueOnce({
+          data: tagsResponse,
+          loading: false,
+          networkStatus: 7,
+        } as never)
+        .mockResolvedValueOnce({
+          data: buildRoomsByTagResponse([]),
+          loading: false,
+          networkStatus: 7,
+        } as never);
+
+      vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
+
+      await executeAvailableRooms({ tags: ["BSC", "LAB"] });
+
+      const roomsCall = vi.mocked(apolloClient.query).mock.calls[1][0];
+      expect(roomsCall.variables.tagIDs.sort()).toEqual(["tag_000001", "tag_000003"].sort());
+    });
+
+    it("returns an empty result with a warning when no supplied tag exists in the org", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: tagsResponse,
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeAvailableRooms({ tags: ["does-not-exist"] });
+
+      expect(apolloClient.query).toHaveBeenCalledTimes(1);
+      expect(result.total_available).toBe(0);
+      expect(result.available_rooms).toEqual([]);
+      expect(result.warning).toMatch(/no matching tags/i);
+      expect(result.warning).toMatch(/butlr_list_tags/i);
+    });
+
+    it("includes a warning listing unknown tags when some but not all tags resolve", async () => {
+      vi.mocked(apolloClient.query)
+        .mockResolvedValueOnce({
+          data: tagsResponse,
+          loading: false,
+          networkStatus: 7,
+        } as never)
+        .mockResolvedValueOnce({
+          data: buildRoomsByTagResponse([]),
+          loading: false,
+          networkStatus: 7,
+        } as never);
+
+      vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([]);
+
+      const result = await executeAvailableRooms({
+        tags: ["bsc", "does-not-exist", "also-missing"],
+      });
+
+      const roomsCall = vi.mocked(apolloClient.query).mock.calls[1][0];
+      expect(roomsCall.variables.tagIDs).toEqual(["tag_000001"]);
+      expect(result.warning).toMatch(/does-not-exist/);
+      expect(result.warning).toMatch(/also-missing/);
+    });
+
+    it("unwraps roomsByTag.data correctly (regression: previously treated as array)", async () => {
+      vi.mocked(apolloClient.query)
+        .mockResolvedValueOnce({
+          data: tagsResponse,
+          loading: false,
+          networkStatus: 7,
+        } as never)
+        .mockResolvedValueOnce({
+          data: buildRoomsByTagResponse(["room_000001", "room_000002", "room_000003"]),
+          loading: false,
+          networkStatus: 7,
+        } as never);
+
+      vi.mocked(reportingClient.getCurrentOccupancy).mockResolvedValue([
+        {
+          start: "2025-10-13T00:00:00Z",
+          measurement: "room_occupancy",
+          value: 0,
+          asset_id: "room_000001",
+          asset_name: "Tagged Room 1",
+        },
+        {
+          start: "2025-10-13T00:00:00Z",
+          measurement: "room_occupancy",
+          value: 0,
+          asset_id: "room_000002",
+          asset_name: "Tagged Room 2",
+        },
+        {
+          start: "2025-10-13T00:00:00Z",
+          measurement: "room_occupancy",
+          value: 5,
+          asset_id: "room_000003",
+          asset_name: "Tagged Room 3",
+        },
+      ]);
+
+      const result = await executeAvailableRooms({ tags: ["bsc"] });
+
+      expect(result.total_available).toBe(2);
+      expect(result.available_rooms.map((r) => r.id).sort()).toEqual([
+        "room_000001",
+        "room_000002",
+      ]);
+    });
+  });
+
   describe("Available room structure", () => {
     it("includes required fields in each available room", async () => {
       const fixture = loadGraphQLFixture("full-topology-org");

--- a/src/tools/__tests__/integration/butlr-list-tags.integration.test.ts
+++ b/src/tools/__tests__/integration/butlr-list-tags.integration.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { executeListTags } from "../../butlr-list-tags.js";
+import { apolloClient } from "../../../clients/graphql-client.js";
+import { loadGraphQLFixture } from "../../../__mocks__/apollo-client.js";
+
+vi.mock("../../../clients/graphql-client.js", () => ({
+  apolloClient: {
+    query: vi.fn(),
+  },
+}));
+
+describe("butlr_list_tags - Integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Default (no args)", () => {
+    it("returns all tags with footprint counts across rooms, zones, floors", async () => {
+      const fixture = loadGraphQLFixture("tags-list");
+
+      vi.mocked(apolloClient.query).mockResolvedValue({
+        data: fixture,
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeListTags({});
+
+      expect(result.total).toBe(5);
+      expect(result.tags).toHaveLength(5);
+
+      const bsc = result.tags.find((t) => t.name === "bsc");
+      expect(bsc).toBeDefined();
+      expect(bsc?.id).toBe("tag_000001");
+      expect(bsc?.applied_to).toEqual({ rooms: 0, zones: 3, floors: 0 });
+
+      const lab = result.tags.find((t) => t.name === "lab");
+      expect(lab?.applied_to).toEqual({ rooms: 2, zones: 1, floors: 1 });
+    });
+
+    it("includes a timestamp in ISO-8601 format", async () => {
+      const fixture = loadGraphQLFixture("tags-list");
+      vi.mocked(apolloClient.query).mockResolvedValue({
+        data: fixture,
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeListTags({});
+
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it("sorts tags by total usage descending", async () => {
+      const fixture = loadGraphQLFixture("tags-list");
+      vi.mocked(apolloClient.query).mockResolvedValue({
+        data: fixture,
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeListTags({});
+
+      // bsc (3 zones) should come before lab (2+1+1=4)... actually lab=4 > bsc=3
+      // Order: lab(4) > bsc(3) > 4ft(2) > BSC-equip(1) > unused-tag(0)
+      expect(result.tags.map((t) => t.name)).toEqual([
+        "lab",
+        "bsc",
+        "4ft",
+        "BSC-equip",
+        "unused-tag",
+      ]);
+    });
+  });
+
+  describe("name_contains filter", () => {
+    it("filters tags by case-insensitive substring", async () => {
+      const fixture = loadGraphQLFixture("tags-list");
+      vi.mocked(apolloClient.query).mockResolvedValue({
+        data: fixture,
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeListTags({ name_contains: "bsc" });
+
+      // Matches bsc and BSC-equip (case-insensitive)
+      const names = result.tags.map((t) => t.name).sort();
+      expect(names).toEqual(["BSC-equip", "bsc"]);
+      expect(result.total).toBe(2);
+    });
+
+    it("returns empty list when no tags match", async () => {
+      const fixture = loadGraphQLFixture("tags-list");
+      vi.mocked(apolloClient.query).mockResolvedValue({
+        data: fixture,
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeListTags({ name_contains: "nonexistent-xyz" });
+
+      expect(result.tags).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe("min_usage filter", () => {
+    it("excludes tags whose total application count is below the threshold", async () => {
+      const fixture = loadGraphQLFixture("tags-list");
+      vi.mocked(apolloClient.query).mockResolvedValue({
+        data: fixture,
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeListTags({ min_usage: 3 });
+
+      // Only bsc(3) and lab(4) meet threshold; 4ft(2), BSC-equip(1), unused-tag(0) excluded
+      expect(result.tags.map((t) => t.name).sort()).toEqual(["bsc", "lab"]);
+      expect(result.total).toBe(2);
+    });
+
+    it("min_usage of 1 excludes only entirely unused tags", async () => {
+      const fixture = loadGraphQLFixture("tags-list");
+      vi.mocked(apolloClient.query).mockResolvedValue({
+        data: fixture,
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeListTags({ min_usage: 1 });
+
+      expect(result.tags.find((t) => t.name === "unused-tag")).toBeUndefined();
+      expect(result.total).toBe(4);
+    });
+  });
+
+  describe("Empty org", () => {
+    it("returns total=0 and empty tags array when org has no tags", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValue({
+        data: { tags: [] },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeListTags({});
+
+      expect(result.tags).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it("handles a null tags response from the API", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValue({
+        data: { tags: null },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeListTags({});
+
+      expect(result.tags).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe("Error translation", () => {
+    it("translates a GraphQL auth error into a user-facing message", async () => {
+      vi.mocked(apolloClient.query).mockRejectedValue({
+        networkError: { statusCode: 401, message: "Unauthorized" },
+      });
+
+      await expect(executeListTags({})).rejects.toThrow(/Authentication failed/i);
+    });
+  });
+});

--- a/src/tools/__tests__/integration/butlr-list-tags.integration.test.ts
+++ b/src/tools/__tests__/integration/butlr-list-tags.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import { executeListTags } from "../../butlr-list-tags.js";
 import { apolloClient } from "../../../clients/graphql-client.js";
 import { loadGraphQLFixture } from "../../../__mocks__/apollo-client.js";
@@ -29,13 +30,13 @@ describe("butlr_list_tags - Integration", () => {
       expect(result.total).toBe(5);
       expect(result.tags).toHaveLength(5);
 
-      const bsc = result.tags.find((t) => t.name === "bsc");
-      expect(bsc).toBeDefined();
-      expect(bsc?.id).toBe("tag_000001");
-      expect(bsc?.applied_to).toEqual({ rooms: 0, zones: 3, floors: 0 });
+      const videoconf = result.tags.find((t) => t.name === "videoconf");
+      expect(videoconf).toBeDefined();
+      expect(videoconf?.id).toBe("tag_000001");
+      expect(videoconf?.applied_to).toEqual({ rooms: 0, zones: 3, floors: 0 });
 
-      const lab = result.tags.find((t) => t.name === "lab");
-      expect(lab?.applied_to).toEqual({ rooms: 2, zones: 1, floors: 1 });
+      const huddle = result.tags.find((t) => t.name === "huddle");
+      expect(huddle?.applied_to).toEqual({ rooms: 2, zones: 1, floors: 1 });
     });
 
     it("includes a timestamp in ISO-8601 format", async () => {
@@ -61,13 +62,12 @@ describe("butlr_list_tags - Integration", () => {
 
       const result = await executeListTags({});
 
-      // bsc (3 zones) should come before lab (2+1+1=4)... actually lab=4 > bsc=3
-      // Order: lab(4) > bsc(3) > 4ft(2) > BSC-equip(1) > unused-tag(0)
+      // Totals: huddle=4, videoconf=3, focus=2, videoconf-large=1, unused-tag=0
       expect(result.tags.map((t) => t.name)).toEqual([
-        "lab",
-        "bsc",
-        "4ft",
-        "BSC-equip",
+        "huddle",
+        "videoconf",
+        "focus",
+        "videoconf-large",
         "unused-tag",
       ]);
     });
@@ -82,11 +82,11 @@ describe("butlr_list_tags - Integration", () => {
         networkStatus: 7,
       } as never);
 
-      const result = await executeListTags({ name_contains: "bsc" });
+      const result = await executeListTags({ name_contains: "VIDEOCONF" });
 
-      // Matches bsc and BSC-equip (case-insensitive)
+      // Matches videoconf and videoconf-large (case-insensitive)
       const names = result.tags.map((t) => t.name).sort();
-      expect(names).toEqual(["BSC-equip", "bsc"]);
+      expect(names).toEqual(["videoconf", "videoconf-large"]);
       expect(result.total).toBe(2);
     });
 
@@ -116,8 +116,8 @@ describe("butlr_list_tags - Integration", () => {
 
       const result = await executeListTags({ min_usage: 3 });
 
-      // Only bsc(3) and lab(4) meet threshold; 4ft(2), BSC-equip(1), unused-tag(0) excluded
-      expect(result.tags.map((t) => t.name).sort()).toEqual(["bsc", "lab"]);
+      // Only videoconf(3) and huddle(4) meet threshold; focus(2), videoconf-large(1), unused-tag(0) excluded
+      expect(result.tags.map((t) => t.name).sort()).toEqual(["huddle", "videoconf"]);
       expect(result.total).toBe(2);
     });
 
@@ -171,6 +171,25 @@ describe("butlr_list_tags - Integration", () => {
       });
 
       await expect(executeListTags({})).rejects.toThrow(/Authentication failed/i);
+    });
+
+    it("throws on a CombinedGraphQLErrors result.error rather than coercing data:null to []", async () => {
+      // Apollo Client 4.x with errorPolicy:'all' resolves with `result.error`
+      // populated. Without explicit handling, the tool would silently report
+      // an empty org instead of surfacing the failure.
+      const combined = new CombinedGraphQLErrors(
+        { data: { tags: null }, errors: [{ message: "Forbidden" }] },
+        [{ message: "Forbidden", extensions: { code: "UNAUTHENTICATED" } }]
+      );
+
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: { tags: null },
+        error: combined,
+        loading: false,
+        networkStatus: 8,
+      } as never);
+
+      await expect(executeListTags({})).rejects.toThrow(/\[AUTH_EXPIRED\]/);
     });
   });
 });

--- a/src/tools/butlr-available-rooms.ts
+++ b/src/tools/butlr-available-rooms.ts
@@ -6,11 +6,31 @@ import type { Room, Building, Floor } from "../clients/types.js";
 import { getCurrentOccupancy } from "../clients/reporting-client.js";
 import { buildAvailableRoomsSummary } from "../utils/natural-language.js";
 import { getCachedOccupancy, setBulkCachedOccupancy } from "../cache/occupancy-cache.js";
-import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
-import { GET_TAGS_MINIMAL } from "../clients/queries/tags.js";
+import { rethrowIfGraphQLError, throwIfGraphQLErrors } from "../utils/graphql-helpers.js";
+import {
+  GET_TAGS_MINIMAL,
+  asTagId,
+  asTagName,
+  type TagId,
+  type TagName,
+} from "../clients/queries/tags.js";
 import type { AvailableRoom, AvailableRoomsResponse, BuildingContext } from "../types/responses.js";
 import { debug } from "../utils/debug.js";
-import { withToolErrorHandling } from "../errors/mcp-errors.js";
+import {
+  withToolErrorHandling,
+  formatMCPError,
+  MCPErrorCode,
+  type MCPError,
+} from "../errors/mcp-errors.js";
+
+function throwInternalError(message: string): never {
+  const mcpError: MCPError = {
+    code: MCPErrorCode.INTERNAL_ERROR,
+    message,
+    retryable: true,
+  };
+  throw new Error(formatMCPError(mcpError));
+}
 
 /** Shared shape — used by both registerTool (SDK schema) and full validation */
 const availableRoomsInputShape = {
@@ -40,7 +60,7 @@ const availableRoomsInputShape = {
 
   tag_match: z
     .enum(["all", "any"])
-    .optional()
+    .default("all")
     .describe(
       "Multi-tag semantics when tags has more than one entry: 'all' (default) requires every tag, 'any' requires at least one"
     ),
@@ -179,7 +199,7 @@ const GET_ROOMS_BY_BUILDING = gql`
   }
 `;
 
-const GET_ROOMS_BY_TAG = gql`
+export const GET_ROOMS_BY_TAG = gql`
   query GetRoomsByTag($tagIDs: [String!]!, $useOR: Boolean) {
     roomsByTag(tagIDs: $tagIDs, useOR: $useOR) {
       data {
@@ -260,15 +280,16 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
   let buildings: Building[] = [];
   let floors: Floor[] = [];
   const warnings: string[] = [];
+  let unknownTagNames: TagName[] = [];
 
   try {
     if (args.floor_id) {
-      // Query specific floor
       const result = await apolloClient.query<{ floor: Floor }>({
         query: GET_ROOMS_BY_FLOOR,
         variables: { floorId: args.floor_id },
         fetchPolicy: "network-only",
       });
+      throwIfGraphQLErrors(result);
 
       if (!result.data?.floor) {
         throw new Error(`Floor ${args.floor_id} not found`);
@@ -278,12 +299,12 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
       floors = [result.data.floor];
       buildings = result.data.floor.building ? [result.data.floor.building] : [];
     } else if (args.building_id) {
-      // Query specific building
       const result = await apolloClient.query<{ building: Building }>({
         query: GET_ROOMS_BY_BUILDING,
         variables: { buildingId: args.building_id },
         fetchPolicy: "network-only",
       });
+      throwIfGraphQLErrors(result);
 
       if (!result.data?.building) {
         throw new Error(`Building ${args.building_id} not found`);
@@ -300,13 +321,19 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
         query: GET_TAGS_MINIMAL,
         fetchPolicy: "network-only",
       });
+      throwIfGraphQLErrors(tagsResult);
 
       const allTags = tagsResult.data?.tags ?? [];
-      const lookup = new Map(allTags.map((t) => [t.name.toLowerCase(), t.id]));
+      // Lookup is keyed by lowercased name; values are typed TagIds so the
+      // resolver boundary cannot accidentally surface raw names downstream.
+      const lookup = new Map<string, TagId>(
+        allTags.map((t) => [t.name.toLowerCase(), asTagId(t.id)])
+      );
 
-      const resolvedIDs: string[] = [];
-      const unknownNames: string[] = [];
-      for (const name of args.tags) {
+      const resolvedIDs: TagId[] = [];
+      const unknownNames: TagName[] = [];
+      for (const rawName of args.tags) {
+        const name = asTagName(rawName);
         const id = lookup.get(name.toLowerCase());
         if (id) {
           resolvedIDs.push(id);
@@ -316,21 +343,41 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
       }
 
       if (resolvedIDs.length === 0) {
-        const response: AvailableRoomsResponse = {
+        return {
           summary: buildAvailableRoomsSummary({ count: 0, roomType: args.tags?.[0] }),
           available_rooms: [],
           total_available: 0,
           showing: 0,
           timestamp: new Date().toISOString(),
           filtered_by: args,
+          unknown_tags: unknownNames,
           warning:
             `No matching tags found in this org for: ${unknownNames.join(", ")}. ` +
             "Use butlr_list_tags to see available tag names.",
         };
-        return response;
+      }
+
+      // Under tag_match='all' (the default), an unresolved tag means the AND
+      // constraint is unsatisfiable — querying with the resolved subset would
+      // return a strictly broader result that silently answers a different
+      // question. Only continue-with-warning is safe under tag_match='any'.
+      if (unknownNames.length > 0 && args.tag_match !== "any") {
+        return {
+          summary: buildAvailableRoomsSummary({ count: 0, roomType: args.tags?.[0] }),
+          available_rooms: [],
+          total_available: 0,
+          showing: 0,
+          timestamp: new Date().toISOString(),
+          filtered_by: args,
+          unknown_tags: unknownNames,
+          warning:
+            `Cannot satisfy tag_match='all': unknown tag(s) ${unknownNames.join(", ")}. ` +
+            "Use butlr_list_tags to see available tag names, or pass tag_match='any' to match rooms tagged with any of the supplied tags.",
+        };
       }
 
       if (unknownNames.length > 0) {
+        unknownTagNames = unknownNames;
         warnings.push(
           `Unknown tag(s) ignored: ${unknownNames.join(", ")}. Use butlr_list_tags to see available tag names.`
         );
@@ -343,9 +390,12 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
         variables: { tagIDs: resolvedIDs, useOR },
         fetchPolicy: "network-only",
       });
+      throwIfGraphQLErrors(result);
 
       if (!result.data?.roomsByTag?.data) {
-        throw new Error("Invalid response structure from API");
+        throwInternalError(
+          "Unexpected response shape from roomsByTag query (missing data envelope). Please retry; if persistent, the upstream API contract may have changed."
+        );
       }
 
       rooms = result.data.roomsByTag.data;
@@ -360,16 +410,18 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
         }
       }
     } else {
-      // Query all rooms (org-wide)
       const result = await apolloClient.query<{
         sites: { data: { buildings: Building[] }[] };
       }>({
         query: GET_ALL_ROOMS,
         fetchPolicy: "network-only",
       });
+      throwIfGraphQLErrors(result);
 
       if (!result.data?.sites?.data) {
-        throw new Error("Invalid response structure from API");
+        throwInternalError(
+          "Unexpected response shape from sites query (missing data envelope). Please retry; if persistent, the upstream API contract may have changed."
+        );
       }
 
       buildings = result.data.sites.data.flatMap((s) => s.buildings || []);
@@ -423,6 +475,10 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
 
     if (warnings.length > 0) {
       response.warning = warnings.join(" ");
+    }
+
+    if (unknownTagNames.length > 0) {
+      response.unknown_tags = unknownTagNames;
     }
 
     return response;
@@ -591,6 +647,10 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
 
   if (warnings.length > 0) {
     response.warning = warnings.join(" ");
+  }
+
+  if (unknownTagNames.length > 0) {
+    response.unknown_tags = unknownTagNames;
   }
 
   return response;

--- a/src/tools/butlr-available-rooms.ts
+++ b/src/tools/butlr-available-rooms.ts
@@ -7,6 +7,7 @@ import { getCurrentOccupancy } from "../clients/reporting-client.js";
 import { buildAvailableRoomsSummary } from "../utils/natural-language.js";
 import { getCachedOccupancy, setBulkCachedOccupancy } from "../cache/occupancy-cache.js";
 import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
+import { GET_TAGS_MINIMAL } from "../clients/queries/tags.js";
 import type { AvailableRoom, AvailableRoomsResponse, BuildingContext } from "../types/responses.js";
 import { debug } from "../utils/debug.js";
 import { withToolErrorHandling } from "../errors/mcp-errors.js";
@@ -33,7 +34,16 @@ const availableRoomsInputShape = {
     .array(z.string().min(1, "Tag cannot be empty").trim())
     .min(1, "tags array cannot be empty")
     .optional()
-    .describe("Filter by room tags"),
+    .describe(
+      "Filter by tag names (case-insensitive). Use butlr_list_tags to discover what tags exist."
+    ),
+
+  tag_match: z
+    .enum(["all", "any"])
+    .optional()
+    .describe(
+      "Multi-tag semantics when tags has more than one entry: 'all' (default) requires every tag, 'any' requires at least one"
+    ),
 
   building_id: z
     .string()
@@ -94,7 +104,7 @@ const AVAILABLE_ROOMS_DESCRIPTION =
   "When to Use:\n" +
   "- Real-time room availability for immediate use (next 5-10 minutes)\n" +
   "- Filter by capacity (e.g., rooms for 6-8 people)\n" +
-  "- Filter by room types using tags (conference, collaboration, focus)\n" +
+  "- Filter by room types using tags (conference, collaboration, focus). Tag names are case-insensitive; pass tag_match='all' (default) or 'any' for multi-tag semantics. Use butlr_list_tags first to discover what tag vocabulary exists in this org.\n" +
   "- Validating room booking system accuracy against actual occupancy\n" +
   "- Analyzing meeting room demand vs. supply across buildings/floors\n\n" +
   "When NOT to Use:\n" +
@@ -170,30 +180,32 @@ const GET_ROOMS_BY_BUILDING = gql`
 `;
 
 const GET_ROOMS_BY_TAG = gql`
-  query GetRoomsByTag($tags: [String!]!) {
-    roomsByTag(tags: $tags) {
-      id
-      name
-      floorID
-      roomType
-      capacity {
-        max
-        mid
-      }
-      area {
-        value
-        unit
-      }
-      coordinates
-      customID
-      floor {
+  query GetRoomsByTag($tagIDs: [String!]!, $useOR: Boolean) {
+    roomsByTag(tagIDs: $tagIDs, useOR: $useOR) {
+      data {
         id
         name
-        building_id
-        building {
+        floorID
+        roomType
+        capacity {
+          max
+          mid
+        }
+        area {
+          value
+          unit
+        }
+        coordinates
+        customID
+        floor {
           id
           name
-          site_id
+          building_id
+          building {
+            id
+            name
+            site_id
+          }
         }
       }
     }
@@ -247,6 +259,7 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
   let rooms: Room[] = [];
   let buildings: Building[] = [];
   let floors: Floor[] = [];
+  const warnings: string[] = [];
 
   try {
     if (args.floor_id) {
@@ -280,18 +293,62 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
       floors = result.data.building.floors || [];
       rooms = floors.flatMap((f) => f.rooms || []);
     } else if (args.tags && args.tags.length > 0) {
-      // Query by tags
-      const result = await apolloClient.query<{ roomsByTag: Room[] }>({
-        query: GET_ROOMS_BY_TAG,
-        variables: { tags: args.tags },
+      // Resolve tag names → tag IDs (the API requires IDs, not names)
+      const tagsResult = await apolloClient.query<{
+        tags: { id: string; name: string }[] | null;
+      }>({
+        query: GET_TAGS_MINIMAL,
         fetchPolicy: "network-only",
       });
 
-      if (!result.data?.roomsByTag) {
+      const allTags = tagsResult.data?.tags ?? [];
+      const lookup = new Map(allTags.map((t) => [t.name.toLowerCase(), t.id]));
+
+      const resolvedIDs: string[] = [];
+      const unknownNames: string[] = [];
+      for (const name of args.tags) {
+        const id = lookup.get(name.toLowerCase());
+        if (id) {
+          resolvedIDs.push(id);
+        } else {
+          unknownNames.push(name);
+        }
+      }
+
+      if (resolvedIDs.length === 0) {
+        const response: AvailableRoomsResponse = {
+          summary: buildAvailableRoomsSummary({ count: 0, roomType: args.tags?.[0] }),
+          available_rooms: [],
+          total_available: 0,
+          showing: 0,
+          timestamp: new Date().toISOString(),
+          filtered_by: args,
+          warning:
+            `No matching tags found in this org for: ${unknownNames.join(", ")}. ` +
+            "Use butlr_list_tags to see available tag names.",
+        };
+        return response;
+      }
+
+      if (unknownNames.length > 0) {
+        warnings.push(
+          `Unknown tag(s) ignored: ${unknownNames.join(", ")}. Use butlr_list_tags to see available tag names.`
+        );
+      }
+
+      const useOR = args.tag_match === "any";
+
+      const result = await apolloClient.query<{ roomsByTag: { data: Room[] } | null }>({
+        query: GET_ROOMS_BY_TAG,
+        variables: { tagIDs: resolvedIDs, useOR },
+        fetchPolicy: "network-only",
+      });
+
+      if (!result.data?.roomsByTag?.data) {
         throw new Error("Invalid response structure from API");
       }
 
-      rooms = result.data.roomsByTag;
+      rooms = result.data.roomsByTag.data;
 
       // Extract floors and buildings from room.floor references
       for (const room of rooms) {
@@ -327,8 +384,6 @@ export async function executeAvailableRooms(args: AvailableRoomsArgs) {
   debug("available-rooms", `Found ${rooms.length} rooms before filtering`);
 
   // Apply capacity filters and track rooms excluded due to missing capacity data
-  const warnings: string[] = [];
-
   if (args.min_capacity !== undefined || args.max_capacity !== undefined) {
     const roomsWithoutCapacity = rooms.filter((r) => !r.capacity?.max).length;
 

--- a/src/tools/butlr-list-tags.ts
+++ b/src/tools/butlr-list-tags.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { apolloClient } from "../clients/graphql-client.js";
 import { GET_TAGS_WITH_USAGE } from "../clients/queries/tags.js";
-import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
+import { rethrowIfGraphQLError, throwIfGraphQLErrors } from "../utils/graphql-helpers.js";
 import { withToolErrorHandling } from "../errors/mcp-errors.js";
 import { debug } from "../utils/debug.js";
 
@@ -33,15 +33,15 @@ const LIST_TAGS_DESCRIPTION =
   "List every tag in the organization, with the footprint (count of rooms, zones, and floors each tag is applied to). Tags are org-scoped labels — the same tag can be attached to any mix of rooms, zones, and floors. Use this tool first to discover what tags exist and which entity types they apply to before calling tag-filtered queries.\n\n" +
   "Primary Users:\n" +
   "- All Users: Discover what tag vocabulary exists in the org and where each tag is used\n" +
-  "- Workplace Manager: Find equipment, zone-type, or department tags before filtering availability\n" +
+  "- Workplace Manager: Find room-type, zone-type, or department tags before filtering availability\n" +
   "- Facilities Coordinator: Audit tag coverage across rooms vs. zones\n\n" +
   "Example Queries:\n" +
   '1. "What tags are used in this org?" → list everything\n' +
-  '2. "Show me tags related to BSC" → name_contains: "bsc"\n' +
+  '2. "Show me video-conferencing tags" → name_contains: "videoconf"\n' +
   '3. "Which tags are actually in use?" → min_usage: 1\n' +
-  '4. "Find equipment tags applied to many zones" → list, then look at applied_to.zones\n\n' +
+  '4. "Find tags applied to many zones" → list, then look at applied_to.zones\n\n' +
   "When to Use:\n" +
-  "- Before any tag-based filter, to map a human term (e.g. 'bsc') to the right tag id and entity level\n" +
+  "- Before any tag-based filter, to map a human term (e.g. 'videoconf') to the right tag id and entity level\n" +
   "- To understand whether a tag lives on rooms, zones, floors, or several levels at once\n" +
   "- To audit tagging hygiene (unused tags, single-level tags, etc.)\n\n" +
   "When NOT to Use:\n" +
@@ -94,6 +94,7 @@ export async function executeListTags(args: ListTagsArgs): Promise<ListTagsRespo
       fetchPolicy: "network-only",
     });
 
+    throwIfGraphQLErrors(result);
     rawTags = result.data?.tags ?? [];
   } catch (error: unknown) {
     rethrowIfGraphQLError(error);

--- a/src/tools/butlr-list-tags.ts
+++ b/src/tools/butlr-list-tags.ts
@@ -1,0 +1,160 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { apolloClient } from "../clients/graphql-client.js";
+import { GET_TAGS_WITH_USAGE } from "../clients/queries/tags.js";
+import { rethrowIfGraphQLError } from "../utils/graphql-helpers.js";
+import { withToolErrorHandling } from "../errors/mcp-errors.js";
+import { debug } from "../utils/debug.js";
+
+const listTagsInputShape = {
+  name_contains: z
+    .string()
+    .min(1, "name_contains cannot be empty")
+    .max(200, "name_contains too long (max: 200 chars)")
+    .optional()
+    .describe("Case-insensitive substring filter on tag name"),
+
+  min_usage: z
+    .number()
+    .int("min_usage must be an integer")
+    .min(0, "min_usage must be >= 0")
+    .max(100000)
+    .optional()
+    .describe(
+      "Exclude tags whose total application count (rooms + zones + floors) is below this threshold"
+    ),
+};
+
+export const ListTagsArgsSchema = z.object(listTagsInputShape).strict();
+
+export type ListTagsArgs = z.output<typeof ListTagsArgsSchema>;
+
+const LIST_TAGS_DESCRIPTION =
+  "List every tag in the organization, with the footprint (count of rooms, zones, and floors each tag is applied to). Tags are org-scoped labels — the same tag can be attached to any mix of rooms, zones, and floors. Use this tool first to discover what tags exist and which entity types they apply to before calling tag-filtered queries.\n\n" +
+  "Primary Users:\n" +
+  "- All Users: Discover what tag vocabulary exists in the org and where each tag is used\n" +
+  "- Workplace Manager: Find equipment, zone-type, or department tags before filtering availability\n" +
+  "- Facilities Coordinator: Audit tag coverage across rooms vs. zones\n\n" +
+  "Example Queries:\n" +
+  '1. "What tags are used in this org?" → list everything\n' +
+  '2. "Show me tags related to BSC" → name_contains: "bsc"\n' +
+  '3. "Which tags are actually in use?" → min_usage: 1\n' +
+  '4. "Find equipment tags applied to many zones" → list, then look at applied_to.zones\n\n' +
+  "When to Use:\n" +
+  "- Before any tag-based filter, to map a human term (e.g. 'bsc') to the right tag id and entity level\n" +
+  "- To understand whether a tag lives on rooms, zones, floors, or several levels at once\n" +
+  "- To audit tagging hygiene (unused tags, single-level tags, etc.)\n\n" +
+  "When NOT to Use:\n" +
+  "- You already have tag IDs and want the actual tagged rooms/zones — call the appropriate tag-filtered tool instead\n" +
+  "- You want full topology browsing — use butlr_list_topology\n\n" +
+  "Response Shape: { tags: [{ id, name, applied_to: { rooms, zones, floors } }], total, timestamp }. Tags are sorted by total usage descending (most-used first).\n\n" +
+  "Note on coverage: spot-level tags exist in the data model but are not yet exposed by this tool — applied_to includes rooms, zones, and floors only.\n\n" +
+  "See Also: butlr_available_rooms (uses tag IDs from this tool), butlr_search_assets, butlr_list_topology";
+
+export interface TagFootprint {
+  rooms: number;
+  zones: number;
+  floors: number;
+}
+
+export interface TagSummary {
+  id: string;
+  name: string;
+  applied_to: TagFootprint;
+}
+
+export interface ListTagsResponse {
+  tags: TagSummary[];
+  total: number;
+  timestamp: string;
+  filtered_by?: Record<string, unknown>;
+}
+
+interface RawTag {
+  id: string;
+  name: string;
+  organization_id?: string;
+  rooms?: Array<{ id: string }> | null;
+  zones?: Array<{ id: string }> | null;
+  floors?: Array<{ id: string }> | null;
+}
+
+function totalUsage(t: TagSummary): number {
+  return t.applied_to.rooms + t.applied_to.zones + t.applied_to.floors;
+}
+
+export async function executeListTags(args: ListTagsArgs): Promise<ListTagsResponse> {
+  debug("list-tags", "Listing tags with args:", JSON.stringify(args));
+
+  let rawTags: RawTag[] = [];
+
+  try {
+    const result = await apolloClient.query<{ tags: RawTag[] | null }>({
+      query: GET_TAGS_WITH_USAGE,
+      fetchPolicy: "network-only",
+    });
+
+    rawTags = result.data?.tags ?? [];
+  } catch (error: unknown) {
+    rethrowIfGraphQLError(error);
+    throw error;
+  }
+
+  let tags: TagSummary[] = rawTags.map((t) => ({
+    id: t.id,
+    name: t.name,
+    applied_to: {
+      rooms: t.rooms?.length ?? 0,
+      zones: t.zones?.length ?? 0,
+      floors: t.floors?.length ?? 0,
+    },
+  }));
+
+  if (args.name_contains) {
+    const needle = args.name_contains.toLowerCase();
+    tags = tags.filter((t) => t.name.toLowerCase().includes(needle));
+  }
+
+  if (args.min_usage !== undefined) {
+    const threshold = args.min_usage;
+    tags = tags.filter((t) => totalUsage(t) >= threshold);
+  }
+
+  tags.sort((a, b) => totalUsage(b) - totalUsage(a));
+
+  const response: ListTagsResponse = {
+    tags,
+    total: tags.length,
+    timestamp: new Date().toISOString(),
+  };
+
+  if (Object.keys(args).length > 0) {
+    response.filtered_by = args;
+  }
+
+  return response;
+}
+
+export function registerListTags(server: McpServer): void {
+  server.registerTool(
+    "butlr_list_tags",
+    {
+      title: "List Butlr Tags",
+      description: LIST_TAGS_DESCRIPTION,
+      inputSchema: listTagsInputShape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    withToolErrorHandling(async (args) => {
+      const validated = ListTagsArgsSchema.parse(args);
+      const result = await executeListTags(validated);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      };
+    })
+  );
+}

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -82,6 +82,8 @@ export interface AvailableRoomsResponse {
   filtered_by?: Record<string, unknown>;
   building_context?: BuildingContext;
   warning?: string;
+  /** Tag names from the request that did not resolve to any tag in this org. */
+  unknown_tags?: string[];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/graphql-helpers.ts
+++ b/src/utils/graphql-helpers.ts
@@ -5,6 +5,7 @@
  * across tool implementations.
  */
 
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import type { Sensor, Hive } from "../clients/types.js";
 import { translateGraphQLError, formatMCPError } from "../errors/mcp-errors.js";
 
@@ -23,6 +24,32 @@ export function rethrowIfGraphQLError(error: unknown): void {
     const mcpError = translateGraphQLError(error as Parameters<typeof translateGraphQLError>[0]);
     throw new Error(formatMCPError(mcpError));
   }
+}
+
+/**
+ * Apollo's global `errorPolicy: "all"` resolves rather than rejects on GraphQL
+ * errors, returning `{ data: <partial>, error: CombinedGraphQLErrors }`.
+ * Without an explicit check, code paths like `result.data?.tags ?? []` silently
+ * coerce a backend failure into "the org has zero rows" — a high-impact silent
+ * failure for filter/discovery tools.
+ *
+ * Call this immediately after `apolloClient.query(...)` to translate any
+ * GraphQL/network errors into the standard MCP error format.
+ */
+export function throwIfGraphQLErrors(result: { error?: unknown }): void {
+  if (!result.error) return;
+
+  if (CombinedGraphQLErrors.is(result.error)) {
+    rethrowIfGraphQLError({
+      graphQLErrors: result.error.errors.map((e) => ({
+        message: e.message,
+        extensions: e.extensions,
+      })),
+    });
+  }
+
+  // Surface other ErrorLike shapes (e.g. ServerError) for the outer catch.
+  throw result.error;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `butlr_list_tags` — discovers the org's tag vocabulary and reports per-level usage counts (`applied_to: { rooms, zones, floors }`), so the LLM can map a human term to the right tag id and the right entity level before filtering.
- Fixes the broken tag filter in `butlr_available_rooms`. The existing query was sending tag *names* via `roomsByTag(tags: …)`, but the API requires tag *IDs* via `roomsByTag(tagIDs: …, useOR:)`. The tool now resolves names → IDs case-insensitively, picks AND/OR semantics from a new `tag_match` arg, and unwraps the `Rooms.data` wrapper. Unknown tag names produce a clear warning pointing users to `butlr_list_tags`.
- Bumps version to `0.2.0` (new tool warrants a minor bump).

## Why

Production data investigation surfaced two issues:

1. The existing `available_rooms` tag filter was silently broken — wrong GraphQL argument name and wrong response unwrapping. No test covered the path.
2. There was no way for the LLM to discover what tags exist in an org, so even a fixed filter would be hard to use in practice.

In orgs that lean on tagging heavily, tags are predominantly applied at the zone level (often as equipment or space-type descriptors), with a smaller footprint on rooms and floors. `butlr_list_tags` + the room-tag fix together unblock tag-based discovery for room-level workflows. A follow-up PR can add zone-level tag filtering using the same name-resolution path; that's where the densest tagging usually lives.

Spot-level tags exist in the data model (`spots.tag_ids`) but are not yet exposed by the API in a queryable form (no `Tag.spots` field, no `spotsByTag` query), and there is effectively no spot tagging in production today. Deliberately deferred; the response shape leaves room to add a `spots` count later without breaking consumers.

## Test plan

- [x] `npm test` — 459 tests pass (added 17: 10 for the new tool, 7 for the tag-filter regression including AND/OR semantics, case-insensitive name resolution, unknown-tag warnings, and a regression test for the `roomsByTag.data` unwrapping bug)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings (only pre-existing ones)
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] Pre-commit hook ran the full suite
- [ ] Manual smoke against a tagged org once published: call `butlr_list_tags`, verify it returns the expected tag set with realistic footprint counts, then call `butlr_available_rooms({tags: [<known room-tag>], tag_match: "all"})` and verify it returns rooms (not an error)

## Notes

- Tags are org-scoped (single `tags` table, no per-level namespace) — `butlr_list_tags` lists all tags in one call and reports the footprint across rooms/zones/floors so the LLM can pick the right downstream query.
- The `available_rooms` tool's response gains an optional `warning` field when some supplied tag names don't exist in the org (it still queries with the tags that do resolve).