### PR TITLE
feat: surface tags on butlr_get_asset_details rooms, zones, and floors (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-12
+
+### Added
+- `butlr_get_asset_details` now returns `tags: [{ id, name }]` on every room, zone, and floor response — closing the asymmetry where callers could find rooms *by* tag (via `butlr_list_tags { include_entities: true }` or `butlr_list_topology { tag_names: [...] }`) but couldn't see *which* tags a known asset carries. Buildings and sites do not have tags in the data model, so their responses are unchanged. The field is always present (`[]` when the asset has no tags) so consumers can rely on a stable response shape. The shape `{id, name}` mirrors the `TaggedEntityRef` projection used elsewhere for consistency. Adds an integration-test suite for `butlr_get_asset_details` (previously uncovered).
+
 ## [0.3.0] - 2026-05-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@butlr/butlr-mcp-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@butlr/butlr-mcp-server",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@butlr/butlr-mcp-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Model Context Protocol server providing secure, read-only access to Butlr occupancy and asset data",
   "type": "module",
   "main": "dist/index.js",

--- a/src/clients/queries/tags.ts
+++ b/src/clients/queries/tags.ts
@@ -76,6 +76,24 @@ export interface RawTagWithUsage {
 }
 
 /**
+ * Inline tag projection returned when a Room/Zone/Floor query selects
+ * `tags { id name }` directly (e.g. `butlr_get_asset_details`).
+ *
+ * Lightweight `{id, name}` projection — both fields are required by
+ * the GraphQL schema and surfaced unchanged. Structurally similar to
+ * but intentionally distinct from `TaggedEntityRef`: `TaggedEntityRef`
+ * is best-effort (name optional) and represents the reverse direction
+ * (entities under a tag); `TagRef` represents tags applied to an
+ * entity. The bare name `Tag` is reserved for the full GraphQL Tag
+ * entity (with organization_id, associations, etc.); callers needing
+ * that shape go through `GET_TAGS_WITH_USAGE` instead.
+ */
+export interface TagRef {
+  id: string;
+  name: string;
+}
+
+/**
  * List every tag in the org along with its application footprint.
  *
  * Each tag's `rooms`, `zones`, and `floors` arrays carry both `id` and

--- a/src/clients/types.ts
+++ b/src/clients/types.ts
@@ -2,6 +2,16 @@
  * TypeScript type definitions for Butlr GraphQL API
  */
 
+import type { TagRef } from "./queries/tags.js";
+
+/*
+ * Schema asymmetry: `tags` exists only on Floor/Room/Zone in Butlr's
+ * GraphQL schema (verified by introspection). Building and Site have
+ * no `tags` field — adding one to those interfaces would compile but
+ * any query selecting it would fail at the GraphQL layer. Do not
+ * widen this without confirming the upstream schema.
+ */
+
 export interface Capacity {
   max?: number;
   mid?: number;
@@ -77,6 +87,7 @@ export interface Floor {
   hives?: Hive[];
   floor_plans?: FloorPlan[];
   building: Building;
+  tags: TagRef[];
 }
 
 /**
@@ -100,6 +111,7 @@ export interface Room {
   pir_zero_window?: number;
   sensors?: Sensor[];
   floor: Floor;
+  tags: TagRef[];
 }
 
 /**
@@ -120,6 +132,7 @@ export interface Zone {
   customID?: string;
   note?: string;
   sensors?: Sensor[];
+  tags: TagRef[];
 }
 
 /**

--- a/src/tools/__tests__/integration/butlr-fetch-entity-details.integration.test.ts
+++ b/src/tools/__tests__/integration/butlr-fetch-entity-details.integration.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { parse, type FieldNode, type OperationDefinitionNode } from "graphql";
 import { executeFetchEntityDetails } from "../../butlr-fetch-entity-details.js";
 import { apolloClient } from "../../../clients/graphql-client.js";
+
+function directSelectionsOf(querySource: string, rootField: string): string[] | null {
+  const ast = parse(querySource);
+  for (const def of ast.definitions) {
+    if (def.kind !== "OperationDefinition") continue;
+    const op = def as OperationDefinitionNode;
+    const root = op.selectionSet.selections.find(
+      (s): s is FieldNode => s.kind === "Field" && s.name.value === rootField
+    );
+    if (!root) return null;
+    if (!root.selectionSet) return [];
+    return root.selectionSet.selections
+      .filter((s): s is FieldNode => s.kind === "Field")
+      .map((s) => s.name.value);
+  }
+  return null;
+}
 
 // Mock the GraphQL client
 vi.mock("../../../clients/graphql-client.js", () => ({
@@ -280,6 +298,84 @@ describe("butlr_fetch_entity_details - Integration", () => {
       const missing = result.entities.find((e) => e.id === "sensor_002");
       expect(missing?.error).toBe("Asset not found");
       expect(result.warning).toContain("1 of 2 entities failed");
+    });
+  });
+
+  // Sibling-tool symmetry: butlr_get_asset_details already surfaces tags on
+  // room/zone/floor responses. butlr_fetch_entity_details (this tool) must
+  // accept `tags` in its per-type allowlist and emit the correct
+  // subselection (`tags { id name }`) — naked `tags` would be invalid
+  // GraphQL because the field is an object type.
+  describe("Tags field on room/zone/floor", () => {
+    function captureQueryFor(rootField: "room" | "zone" | "floor", responseData: unknown) {
+      let captured = "";
+      vi.mocked(apolloClient.query).mockImplementation((options: never) => {
+        captured =
+          (options as { query?: { loc?: { source?: { body?: string } } } })?.query?.loc?.source
+            ?.body ?? "";
+        return Promise.resolve({
+          data: { [rootField]: responseData },
+          loading: false,
+          networkStatus: 7,
+        } as never);
+      });
+      return () => captured;
+    }
+
+    it("emits `tags { id name }` subselection on room queries", async () => {
+      const getCaptured = captureQueryFor("room", {
+        id: "room_100",
+        tags: [{ id: "t1", name: "lab" }],
+      });
+
+      const result = await executeFetchEntityDetails({
+        ids: ["room_100"],
+        room_fields: ["tags"],
+      });
+
+      const roomSelections = directSelectionsOf(getCaptured(), "room");
+      expect(roomSelections).toContain("tags");
+      expect(roomSelections).toContain("id"); // id is always injected
+      expect(result.entities[0].tags).toEqual([{ id: "t1", name: "lab" }]);
+    });
+
+    it("emits `tags { id name }` subselection on zone queries", async () => {
+      const getCaptured = captureQueryFor("zone", {
+        id: "zone_1",
+        tags: [{ id: "t1", name: "quiet" }],
+      });
+
+      const result = await executeFetchEntityDetails({
+        ids: ["zone_1"],
+        zone_fields: ["tags"],
+      });
+
+      expect(directSelectionsOf(getCaptured(), "zone")).toContain("tags");
+      expect(result.entities[0].tags).toEqual([{ id: "t1", name: "quiet" }]);
+    });
+
+    it("emits `tags { id name }` subselection on floor queries", async () => {
+      const getCaptured = captureQueryFor("floor", {
+        id: "space_1",
+        tags: [],
+      });
+
+      const result = await executeFetchEntityDetails({
+        ids: ["space_1"],
+        floor_fields: ["tags"],
+      });
+
+      expect(directSelectionsOf(getCaptured(), "floor")).toContain("tags");
+      expect(result.entities[0].tags).toEqual([]);
+    });
+
+    it("rejects `tags` as a field for building (Building schema has no tags)", async () => {
+      await expect(
+        executeFetchEntityDetails({
+          ids: ["building_1"],
+          building_fields: ["tags"],
+        })
+      ).rejects.toThrow(/Invalid fields for building/);
     });
   });
 

--- a/src/tools/__tests__/integration/butlr-get-asset-details.integration.test.ts
+++ b/src/tools/__tests__/integration/butlr-get-asset-details.integration.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { parse, type FieldNode, type OperationDefinitionNode } from "graphql";
+import { executeGetAssetDetails } from "../../butlr-get-asset-details.js";
+import { apolloClient } from "../../../clients/graphql-client.js";
+
+vi.mock("../../../clients/graphql-client.js", () => ({
+  apolloClient: {
+    query: vi.fn(),
+  },
+}));
+
+/**
+ * Return the direct field-selection names under the top-level GraphQL field
+ * named `rootField` in `querySource`. Used to assert the wire contract of a
+ * query without depending on whitespace, field order, or punctuation. A
+ * `null` return means the root field itself was not selected.
+ */
+function directSelectionsOf(querySource: string, rootField: string): string[] | null {
+  const ast = parse(querySource);
+  for (const def of ast.definitions) {
+    if (def.kind !== "OperationDefinition") continue;
+    const op = def as OperationDefinitionNode;
+    const root = op.selectionSet.selections.find(
+      (s): s is FieldNode => s.kind === "Field" && s.name.value === rootField
+    );
+    if (!root) return null;
+    if (!root.selectionSet) return [];
+    return root.selectionSet.selections
+      .filter((s): s is FieldNode => s.kind === "Field")
+      .map((s) => s.name.value);
+  }
+  return null;
+}
+
+describe("butlr_get_asset_details - Integration", () => {
+  beforeEach(() => {
+    vi.mocked(apolloClient.query).mockReset();
+  });
+
+  describe("Basic asset lookup", () => {
+    it("returns a room with its scalar metadata", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: {
+          room: {
+            id: "room_100",
+            name: "Conference Room A",
+            roomType: "meeting",
+            customID: "CR-A",
+            capacity: { max: 10, mid: 6 },
+            area: { value: 200, unit: "sqft" },
+            coordinates: [
+              [0, 0],
+              [1, 1],
+            ],
+            rotation: 0,
+            note: null,
+            tags: [],
+          },
+        },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeGetAssetDetails({
+        ids: ["room_100"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+
+      expect(result.requested_count).toBe(1);
+      expect(result.total_count).toBe(1);
+      expect(result.assets).toHaveLength(1);
+      const asset = result.assets[0];
+      expect(asset.id).toBe("room_100");
+      expect(asset.name).toBe("Conference Room A");
+      expect(asset._type).toBe("room");
+      expect(asset.capacity).toEqual({ max: 10, mid: 6 });
+    });
+  });
+
+  describe("Tags on rooms, zones, and floors", () => {
+    it("returns tags as [{id, name}] for a room with tags", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: {
+          room: {
+            id: "room_lab_01",
+            name: "Research Lab A",
+            capacity: { max: 12 },
+            tags: [
+              { id: "tag_research", name: "research" },
+              { id: "tag_high_priority", name: "high priority" },
+            ],
+          },
+        },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeGetAssetDetails({
+        ids: ["room_lab_01"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+
+      const asset = result.assets[0];
+      expect(asset.tags).toEqual([
+        { id: "tag_research", name: "research" },
+        { id: "tag_high_priority", name: "high priority" },
+      ]);
+    });
+
+    it("returns tags: [] when a room has no tags", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: {
+          room: {
+            id: "room_untagged",
+            name: "Untagged Room",
+            capacity: { max: 4 },
+            tags: [],
+          },
+        },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeGetAssetDetails({
+        ids: ["room_untagged"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+
+      const asset = result.assets[0];
+      expect(asset.tags).toEqual([]);
+    });
+
+    it("returns tags for a zone", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: {
+          zone: {
+            id: "zone_peloton_01",
+            name: "Peloton 1",
+            roomID: "room_gym",
+            capacity: { max: 1 },
+            tags: [{ id: "tag_equipment", name: "fitness equipment" }],
+          },
+        },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeGetAssetDetails({
+        ids: ["zone_peloton_01"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+
+      const asset = result.assets[0];
+      expect(asset.tags).toEqual([{ id: "tag_equipment", name: "fitness equipment" }]);
+    });
+
+    it("returns tags for a floor", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: {
+          floor: {
+            id: "space_001",
+            name: "Floor 1",
+            capacity: { max: 200 },
+            tags: [{ id: "tag_amenity", name: "amenity floor" }],
+          },
+        },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeGetAssetDetails({
+        ids: ["space_001"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+
+      const asset = result.assets[0];
+      expect(asset.tags).toEqual([{ id: "tag_amenity", name: "amenity floor" }]);
+    });
+
+    // Buildings and sites do not have a `tags` field in the GraphQL schema
+    // (introspected against the live API). Our query for these types does NOT
+    // select `tags`, so the response should NOT contain a `tags` key.
+    // This pins that contract so a future refactor doesn't accidentally
+    // surface a phantom empty `tags: []` on buildings/sites.
+    it("does not include tags on building responses (data model: no tags on buildings)", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: {
+          building: {
+            id: "building_001",
+            name: "Building",
+            capacity: { max: 1000 },
+          },
+        },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeGetAssetDetails({
+        ids: ["building_001"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+
+      const asset = result.assets[0];
+      expect(asset.tags).toBeUndefined();
+      expect("tags" in asset).toBe(false);
+    });
+
+    it("does not include tags on site responses (data model: no tags on sites)", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: {
+          site: {
+            id: "site_001",
+            name: "HQ",
+            timezone: "America/Los_Angeles",
+          },
+        },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+
+      const result = await executeGetAssetDetails({
+        ids: ["site_001"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+
+      const asset = result.assets[0];
+      expect(asset.tags).toBeUndefined();
+      expect("tags" in asset).toBe(false);
+    });
+  });
+
+  describe("Query shape", () => {
+    // GraphQL Document AST inspection: confirm the room/zone/floor queries
+    // request `tags { id name }` as a direct child of the top-level field,
+    // and confirm the building query does NOT. AST walking is order- and
+    // whitespace-agnostic and also catches "tags moved under a nested
+    // selection" regressions — a literal-string search would not.
+    function captureQueryFor(rootField: "room" | "zone" | "floor" | "building") {
+      let captured = "";
+      vi.mocked(apolloClient.query).mockImplementation((options: never) => {
+        captured =
+          (options as { query?: { loc?: { source?: { body?: string } } } })?.query?.loc?.source
+            ?.body ?? "";
+        return Promise.resolve({
+          data: { [rootField]: { id: `${rootField}_x`, name: "x" } },
+          loading: false,
+          networkStatus: 7,
+        } as never);
+      });
+      return () => captured;
+    }
+
+    it("room query selects tags as a direct child of room", async () => {
+      const getCaptured = captureQueryFor("room");
+      await executeGetAssetDetails({
+        ids: ["room_x"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+      expect(directSelectionsOf(getCaptured(), "room")).toContain("tags");
+    });
+
+    it("zone query selects tags as a direct child of zone", async () => {
+      const getCaptured = captureQueryFor("zone");
+      await executeGetAssetDetails({
+        ids: ["zone_x"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+      expect(directSelectionsOf(getCaptured(), "zone")).toContain("tags");
+    });
+
+    it("floor query selects tags as a direct child of floor (not nested under rooms/zones)", async () => {
+      const getCaptured = captureQueryFor("floor");
+      await executeGetAssetDetails({
+        ids: ["space_x"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+      // Direct child of floor, not buried inside floor.rooms[*]. A future
+      // refactor that pushed `tags { id name }` into the nested rooms block
+      // but dropped it from the floor would be caught here; a substring
+      // regex would not.
+      expect(directSelectionsOf(getCaptured(), "floor")).toContain("tags");
+    });
+
+    it("building query does NOT select tags (Building schema has no tags field)", async () => {
+      const getCaptured = captureQueryFor("building");
+      await executeGetAssetDetails({
+        ids: ["building_x"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+      expect(directSelectionsOf(getCaptured(), "building")).not.toContain("tags");
+    });
+  });
+
+  // Boundary normalization: the MCP tool description guarantees `tags`
+  // is always present as an array on room/zone/floor responses. Apollo's
+  // `errorPolicy: 'all'` + nullable GraphQL list resolvers can yield
+  // `tags: null` or omit the field on partial-error paths. Both shapes
+  // must coerce to `[]` so consumers can safely write `asset.tags.length`.
+  describe("Tags normalization", () => {
+    it("coerces tags: null to []", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: { room: { id: "room_n", name: "x", tags: null } },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+      const result = await executeGetAssetDetails({
+        ids: ["room_n"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+      expect(result.assets[0].tags).toEqual([]);
+    });
+
+    it("coerces missing tags key to [] on a zone response", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: { zone: { id: "zone_n", name: "x" } },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+      const result = await executeGetAssetDetails({
+        ids: ["zone_n"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+      expect(result.assets[0].tags).toEqual([]);
+    });
+
+    it("coerces missing tags key to [] on a floor response", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: { floor: { id: "space_n", name: "x" } },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+      const result = await executeGetAssetDetails({
+        ids: ["space_n"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+      expect(result.assets[0].tags).toEqual([]);
+    });
+
+    it("does NOT inject tags on building responses (no tags in Building schema)", async () => {
+      vi.mocked(apolloClient.query).mockResolvedValueOnce({
+        data: { building: { id: "building_n", name: "x" } },
+        loading: false,
+        networkStatus: 7,
+      } as never);
+      const result = await executeGetAssetDetails({
+        ids: ["building_n"],
+        include_children: true,
+        include_devices: false,
+        include_parent_context: true,
+      });
+      expect("tags" in result.assets[0]).toBe(false);
+    });
+  });
+});

--- a/src/tools/butlr-fetch-entity-details.ts
+++ b/src/tools/butlr-fetch-entity-details.ts
@@ -74,6 +74,13 @@ type FetchEntityDetailsArgs = z.output<typeof FetchEntityDetailsArgsSchema>;
 /**
  * Build GraphQL query dynamically based on requested fields
  */
+// GraphQL object-typed fields require an explicit subselection. The
+// allowlist guard only checks for safe identifiers; the emitted query
+// substitutes the canonical subselection for any field listed here.
+const FIELD_SELECTIONS: Record<string, string> = {
+  tags: "tags { id name }",
+};
+
 function buildQueryForFields(type: string, fields: string[]): ReturnType<typeof gql> {
   // Defense-in-depth: reject any field name that isn't a simple identifier
   for (const field of fields) {
@@ -81,7 +88,7 @@ function buildQueryForFields(type: string, fields: string[]): ReturnType<typeof 
       throw new Error(`Invalid field name: ${field}`);
     }
   }
-  const fieldList = fields.join("\n      ");
+  const fieldList = fields.map((f) => FIELD_SELECTIONS[f] ?? f).join("\n      ");
 
   switch (type) {
     case "site":

--- a/src/tools/butlr-get-asset-details.ts
+++ b/src/tools/butlr-get-asset-details.ts
@@ -66,13 +66,15 @@ const GET_ASSET_DETAILS_DESCRIPTION =
   "5. \"Show me sensor MAC addresses for Room 'Café Barista' for field tech visit\"\n" +
   '6. "Get hive serial numbers and online status for Building 2"\n' +
   '7. "Show me site timezone and all buildings in the Chicago office"\n' +
-  '8. "Get room coordinates and rotation for floor plan mapping"\n\n' +
+  '8. "Get room coordinates and rotation for floor plan mapping"\n' +
+  '9. "Which tags are applied to this room?" (after finding the room ID via butlr_search_assets — tags always returned for rooms/zones/floors)\n\n' +
   "When to Use:\n" +
   "- Have asset IDs and need detailed configuration, metadata, or relationships\n" +
   "- Validating sensor/hive assignments for troubleshooting (which hive is this sensor on?)\n" +
   "- Need room capacities, areas, or coordinates for space planning or floor plan integrations\n" +
   "- Preparing for field technician site visit (need device identifiers: MACs, serials)\n" +
-  "- Building integrations and need to fetch parent context (room → floor → building → site)\n\n" +
+  "- Building integrations and need to fetch parent context (room → floor → building → site)\n" +
+  "- Inspecting which tags a specific room/zone/floor carries without searching the org tag list\n\n" +
   "When NOT to Use:\n" +
   "- Don't have asset IDs yet → use butlr_search_assets first to find IDs by name\n" +
   "- Need real-time occupancy or sensor data → use occupancy/traffic tools instead\n" +
@@ -80,7 +82,8 @@ const GET_ASSET_DETAILS_DESCRIPTION =
   "- Need to update/configure assets → this is read-only; use Butlr Dashboard for changes\n\n" +
   "Options: include_children (default true), include_devices (default false), include_parent_context (default true)\n\n" +
   "Batch Query: Supports multiple IDs in single call - mixed asset types supported\n\n" +
-  "See Also: butlr_search_assets, butlr_list_topology, butlr_fetch_entity_details, butlr_hardware_snapshot";
+  "Tags: rooms, zones, and floors include a `tags: [{id, name}]` array in the response (always present, empty if the asset has no tags). Buildings and sites do not have tags in the data model. Tags appear only on the top-level requested asset — when `include_children: true`, nested rooms/zones inside a floor response do NOT carry their own `tags`; call butlr_get_asset_details again with specific child IDs (up to 50 per batch) to see those. To discover what tag vocabulary exists in the org, use butlr_list_tags.\n\n" +
+  "See Also: butlr_search_assets, butlr_list_topology, butlr_list_tags, butlr_fetch_entity_details, butlr_hardware_snapshot";
 
 /**
  * Input arguments for get_asset_details (output type from Zod schema after defaults applied)
@@ -172,6 +175,12 @@ function buildQuery(
       `;
 
     case "floor":
+      // `tags { id name }` is always selected (no opt-in flag) — tags are
+      // entity metadata on the same level as name/capacity/area, not a
+      // fan-out relation that scales with topology size. The top-level
+      // asset gets its own tags; nested children (rooms/zones below)
+      // stay minimal — call `butlr_get_asset_details` on a specific
+      // child ID to see its tags.
       return gql`
         query GetFloorDetails($id: ID!) {
           floor(id: $id) {
@@ -184,6 +193,7 @@ function buildQuery(
             customID
             capacity { max mid }
             area { value unit }
+            tags { id name }
             ${
               includeParentContext
                 ? `
@@ -250,6 +260,8 @@ function buildQuery(
       `;
 
     case "room":
+      // `tags { id name }` is always selected — entity metadata, not a
+      // fan-out relation. Cost is bounded by the per-entity tag count.
       return gql`
         query GetRoomDetails($id: ID!) {
           room(id: $id) {
@@ -262,6 +274,7 @@ function buildQuery(
             coordinates
             rotation
             note
+            tags { id name }
             ${
               includeParentContext
                 ? `
@@ -301,6 +314,8 @@ function buildQuery(
       `;
 
     case "zone":
+      // `tags { id name }` is always selected — entity metadata, not a
+      // fan-out relation. Cost is bounded by the per-entity tag count.
       return gql`
         query GetZoneDetails($id: ID!) {
           zone(id: $id) {
@@ -313,6 +328,7 @@ function buildQuery(
             coordinates
             rotation
             note
+            tags { id name }
             ${
               includeDevices
                 ? `
@@ -401,7 +417,16 @@ export async function executeGetAssetDetails(args: GetAssetDetailsArgs) {
       }
       const asset = data[type];
       if (asset && typeof asset === "object") {
-        results.push({ ...(asset as Record<string, unknown>), _type: type });
+        const assetRecord = { ...(asset as Record<string, unknown>) };
+        // The MCP tool description guarantees `tags: TagRef[]` is always
+        // present on room/zone/floor responses. Apollo `errorPolicy: 'all'`
+        // and nullable list resolvers can yield `tags: null` or omit the
+        // field on partial-error paths; coerce here so the wire contract
+        // and the TypeScript type agree at the tool boundary.
+        if (type === "room" || type === "zone" || type === "floor") {
+          assetRecord.tags = Array.isArray(assetRecord.tags) ? assetRecord.tags : [];
+        }
+        results.push({ ...assetRecord, _type: type });
       } else {
         debug("get-asset-details", `Asset not found: ${id}`);
       }

--- a/src/utils/field-validator.ts
+++ b/src/utils/field-validator.ts
@@ -68,6 +68,7 @@ const VALID_FIELDS: Record<EntityType, readonly string[]> = {
     "sensors",
     "hives",
     "building",
+    "tags",
   ],
   room: [
     "id",
@@ -82,6 +83,7 @@ const VALID_FIELDS: Record<EntityType, readonly string[]> = {
     "note",
     "sensors",
     "floor",
+    "tags",
   ],
   zone: [
     "id",
@@ -95,6 +97,7 @@ const VALID_FIELDS: Record<EntityType, readonly string[]> = {
     "rotation",
     "note",
     "sensors",
+    "tags",
   ],
   sensor: [
     "id",


### PR DESCRIPTION
## Summary

Closes the asymmetry where, after PR #29 (tag bulk-enumeration / topology tag filter) and PR #31 (bug-fix patch + tag enumeration release) landed, callers could find rooms *by* tag — via `butlr_list_tags { include_entities: true }` or `butlr_list_topology { tag_names: [...] }` — but still couldn't see *which* tags a known room/zone/floor carries. This PR closes that gap by surfacing `tags: [{id, name}]` on every Room, Zone, and Floor response from `butlr_get_asset_details`.

## Dependencies (informational)

- **Lands after** [PR #31](https://github.com/butlrtechnologies/butlr-mcp/pull/31) (no file overlap)
- **Lands after** [PR #29](https://github.com/butlrtechnologies/butlr-mcp/pull/29) (touches `tags.ts` where this PR adds the `TagRef` interface). Both PRs add separate exports to the same file with no semantic conflict.

## Design decisions

- **Always-on, no `include_tags` flag.** Tags are entity metadata on the same level as `name`/`capacity`/`area`, not a fan-out relation that scales with topology size. Cost is bounded by the per-entity tag count (typically 0–10 strings).
- **Top-level only.** When `include_children: true` (default), the floor response's nested `rooms[]` and `zones[]` stay minimal (no tags). Callers wanting tags on those children call `butlr_get_asset_details` again with specific child IDs (the batched form handles up to 50 at a time).
- **Shape: `tags: [{id, name}]`.** Mirrors the GraphQL `tags { id name }` selection 1:1. IDs are needed for follow-up `roomsByTag` filters; names are needed for human-readable output.
- **Empty state: `tags: []`.** Always present, never omitted — predictable shape for consumers. Normalized at the tool boundary so that an upstream `null` or omitted field still surfaces as `[]`.
- **Buildings and sites stay unchanged.** Verified via GraphQL introspection that `Building` and `Site` types don't have a `tags` field. A `types.ts` block comment documents this so a future maintainer doesn't widen it without re-checking the schema.
- **New `TagRef` interface (not bare `Tag`).** Reserves the bare `Tag` name for the future full GraphQL Tag entity; matches the `*Ref` suffix convention used by `TaggedEntityRef`. Both fields are required because the GraphQL schema declares `Tag.name` as non-null.

## Workflow that motivated this

A representative composition that becomes possible once this lands:

```
1. butlr_list_tags { name_contains: "<category>", include_entities: true }
   → flat list of { id, name } for every tagged room/zone/floor
2. butlr_get_asset_details { ids: [room_xxx, ...], include_parent_context: true }
   → capacity, site, building, floor, AND tags (this PR)
3. LLM filters by capacity / site / etc., reads `tags` directly off each asset
```

Without this PR, step 2 returns capacity but not tags — so the LLM can't verify the assets it just fetched are still tagged the way the user expects. This closes that loop.

## Files

- `src/clients/queries/tags.ts` — adds `TagRef = { id, name }` interface
- `src/clients/types.ts` — adds `tags: TagRef[]` (non-optional) to `Room`, `Zone`, `Floor` interfaces + schema-asymmetry block comment
- `src/tools/butlr-get-asset-details.ts` — selects `tags { id name }` on room/zone/floor queries; boundary-normalizes `null`/missing to `[]`; updates the tool description
- `src/tools/butlr-fetch-entity-details.ts` + `src/utils/field-validator.ts` — sibling-tool symmetry: `tags` joins the floor/room/zone allowlist; new `FIELD_SELECTIONS` table emits the correct `tags { id name }` subselection
- `src/tools/__tests__/integration/butlr-get-asset-details.integration.test.ts` — **new file**, fills a pre-existing coverage gap. 15 tests covering scalar metadata, tag presence/absence/empty/null-coercion, and AST guards pinning the `tags { id name }` selection on rooms/zones/floors AND the *absence* of `tags` selection on buildings
- `src/tools/__tests__/integration/butlr-fetch-entity-details.integration.test.ts` — +4 tests for the sibling-tool tag plumbing (AST guards + building rejection)
- `CHANGELOG.md` + `package.json` — version bumped to 0.4.0 (additive public-API change → SemVer MINOR)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 7 pre-existing warnings on unchanged files; 0 new
- [x] `npm run build` — clean
- [x] `npm test` — local suite green (added 4 normalization tests + 4 fetch-entity-details tests on top of the original 11)
- [ ] Manual smoke test post-merge: `butlr_get_asset_details({ ids: [<a-tagged-room-id>] })` returns `tags: [{...}]`; building/site responses do NOT have a `tags` key; `butlr_fetch_entity_details({ ids: [<room>], room_fields: ["tags"] })` returns the same data
