### PR TITLE
fix: warn on offline sensors, not installation_status (v0.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-28
+
+### Fixed
+- `butlr_traffic_flow`'s sensor-path warning now fires on `is_online: false` instead of `installation_status: "UNINSTALLED"`. The status field is a provisioning-workflow checkbox — the API sets it to `UNINSTALLED` at sensor creation and nothing in the data pipeline ever reads it — so fleets routinely stream for years carrying it (customer report: 4 of 5 online sensors on one floor flagged; a survey of a live org found 53 online `UNINSTALLED` sensors and zero `INSTALLED` ones). Online sensors with stale status no longer warn; genuinely offline sensors now do.
+
 ## [0.6.0] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [0.6.1] - 2026-08-28
 
 ### Fixed
-- `butlr_traffic_flow`'s sensor-path warning now fires on `is_online: false` instead of `installation_status: "UNINSTALLED"`. The status field is a provisioning-workflow checkbox — the API sets it to `UNINSTALLED` at sensor creation and nothing in the data pipeline ever reads it — so fleets routinely stream for years carrying it (customer report: 4 of 5 online sensors on one floor flagged; a survey of a live org found 53 online `UNINSTALLED` sensors and zero `INSTALLED` ones). Online sensors with stale status no longer warn; genuinely offline sensors now do.
+- `butlr_traffic_flow` no longer warns on `installation_status: "UNINSTALLED"`. That field is a provisioning-workflow checkbox — the API sets it to `UNINSTALLED` at sensor creation and nothing in the data pipeline ever reads it — so fleets routinely stream with it never flipped, and the warning fired on healthy, online sensors.
+- The replacement offline warning is gated on what it can actually explain: it fires only when every queried traffic sensor is offline (`is_online` by truthiness, matching `butlr_hardware_snapshot` — null/absent counts as offline), the window's total is zero, and the sensor's last heartbeat does not postdate the window (a heartbeat at/after `stop` means the outage began after the queried range, so a zero is real data). The copy names the last-seen time when known and points at `butlr_get_asset_details`, which can see room-less/MAC-less sensors that `butlr_hardware_snapshot` structurally cannot. The room path gets the same warning when all of a room's traffic sensors are offline — a hive outage takes them down together, which is the most confident false zero of all.
+- Known limit, documented rather than guessed at: a sensor that was down during the window but reconnected before the query reports online, and a point-in-time heartbeat cannot reveal the historical gap — such windows still return an unqualified count.
+- `GET_SENSORS_BY_IDS`/`GET_SENSORS_BY_ROOM_IDS` select `last_heartbeat` (used by the gate above) and drop `installation_status`, which nothing read anymore. `Sensor.is_online` is defensively optional in the client types, same rationale as `mode`.
 
 ## [0.6.0] - 2026-08-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@butlr/butlr-mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@butlr/butlr-mcp-server",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@butlr/butlr-mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Model Context Protocol server providing secure, read-only access to Butlr occupancy and asset data",
   "type": "module",
   "main": "dist/index.js",

--- a/src/clients/queries/topology.ts
+++ b/src/clients/queries/topology.ts
@@ -182,7 +182,8 @@ export const GET_ALL_SENSORS = gql`
  * The `sensors` root field accepts an `ids` argument, so a caller that needs
  * one known sensor does not have to download the org's whole inventory and
  * `.find()` in it. Selects only what an ID-addressed lookup needs: identity,
- * mode, parent linkage, and installation status. Use GET_ALL_SENSORS when the
+ * mode, parent linkage, and liveness (is_online + last_heartbeat, which the
+ * offline-warning gate compares against the query window). Use GET_ALL_SENSORS when the
  * caller genuinely needs the full list (e.g. aggregating a room's sensors).
  *
  * Uses snake_case fields (floor_id, room_id) for the same reason as
@@ -201,7 +202,7 @@ export const GET_SENSORS_BY_IDS = gql`
         hive_serial
         is_entrance
         is_online
-        installation_status
+        last_heartbeat
       }
     }
   }
@@ -220,7 +221,7 @@ export const GET_SENSORS_BY_ROOM_IDS = gql`
         hive_serial
         is_entrance
         is_online
-        installation_status
+        last_heartbeat
       }
     }
   }

--- a/src/clients/types.ts
+++ b/src/clients/types.ts
@@ -157,7 +157,11 @@ export interface Sensor {
   hiveID?: string; // camelCase
   hive_id?: string; // snake_case
   hive_serial: string;
-  is_online: boolean;
+  // Defensively optional, same rationale as `mode` above: nothing upstream
+  // guarantees the resolver never returns null for a device that has never
+  // reported, and a non-optional boolean would let `=== false` checks
+  // silently skip null/absent rows the offline handling should catch.
+  is_online?: boolean;
   is_streaming?: boolean;
   height: number;
   center: number[];

--- a/src/tools/__tests__/integration/butlr-traffic-flow.integration.test.ts
+++ b/src/tools/__tests__/integration/butlr-traffic-flow.integration.test.ts
@@ -874,16 +874,16 @@ describe("butlr_traffic_flow - Integration", () => {
       expect(result.traffic.total_entries).toBe(4);
     });
 
-    it("warns instead of reporting a bare zero for an UNINSTALLED sensor", async () => {
+    it("warns instead of reporting a bare zero for an offline sensor", async () => {
       mockGraphQLTopologyAndSensors([
         {
-          id: "sensor_uninstalled",
+          id: "sensor_offline",
           name: "Dock Door",
           mac_address: "aa:bb:cc:dd:ee:07",
           mode: "traffic",
           room_id: "room_test",
           floor_id: "floor_test",
-          installation_status: "UNINSTALLED",
+          is_online: false,
         },
       ]);
 
@@ -892,12 +892,50 @@ describe("butlr_traffic_flow - Integration", () => {
       } as any);
 
       const result = await executeTrafficFlow({
-        space_id_or_name: "sensor_uninstalled",
+        space_id_or_name: "sensor_offline",
         time_window: "1h",
       });
 
       expect(result.traffic.total_traffic).toBe(0);
-      expect(result.warning).toContain("UNINSTALLED");
+      expect(result.warning).toContain("offline");
+    });
+
+    it("does not warn for an online sensor whose installation_status is UNINSTALLED", async () => {
+      // installation_status is a provisioning-workflow checkbox that defaults
+      // to UNINSTALLED at sensor creation and is routinely never flipped —
+      // fleets stream for years carrying it. Warning on it flagged 4 of 5
+      // online sensors on a customer floor.
+      mockGraphQLTopologyAndSensors([
+        {
+          id: "sensor_never_flipped",
+          name: "N. Elevator",
+          mac_address: "aa:bb:cc:dd:ee:08",
+          mode: "traffic",
+          room_id: "room_test",
+          floor_id: "floor_test",
+          is_online: true,
+          installation_status: "UNINSTALLED",
+        },
+      ]);
+
+      vi.spyOn(reportingClient.ReportingRequestBuilder.prototype, "execute").mockResolvedValue({
+        data: [
+          {
+            time: "2026-08-28T17:29:00Z",
+            sensor_id: "sensor_never_flipped",
+            field: "in",
+            value: 2,
+          },
+        ],
+      } as any);
+
+      const result = await executeTrafficFlow({
+        space_id_or_name: "sensor_never_flipped",
+        time_window: "1h",
+      });
+
+      expect(result.traffic.total_entries).toBe(2);
+      expect(result.warning).toBeUndefined();
     });
 
     it("does not name a dangling room when rejecting a presence sensor", async () => {

--- a/src/tools/__tests__/integration/butlr-traffic-flow.integration.test.ts
+++ b/src/tools/__tests__/integration/butlr-traffic-flow.integration.test.ts
@@ -657,6 +657,7 @@ describe("butlr_traffic_flow - Integration", () => {
           name: "Old Door",
           mac_address: "aa:bb:cc:dd:ee:02",
           mode: "traffic",
+          is_online: true,
           room_id: "room_deleted_long_ago",
           floor_id: "floor_test",
         },
@@ -803,6 +804,7 @@ describe("butlr_traffic_flow - Integration", () => {
           name: "Door A",
           mac_address: "aa:bb:cc:dd:ee:05",
           mode: "traffic",
+          is_online: true,
           room_id: "room_test",
           floor_id: "",
         },
@@ -872,6 +874,98 @@ describe("butlr_traffic_flow - Integration", () => {
 
       expect(result.space.name).toBe("New Door");
       expect(result.traffic.total_entries).toBe(4);
+    });
+
+    it("does not warn when an offline sensor's window returned real counts", async () => {
+      // The warning must only qualify a zero the outage can explain — a
+      // sensor that dropped minutes ago can still have thousands of real
+      // movements in the window.
+      mockGraphQLTopologyAndSensors([
+        {
+          id: "sensor_just_dropped",
+          name: "Busy Door",
+          mac_address: "aa:bb:cc:dd:ee:20",
+          mode: "traffic",
+          room_id: "room_test",
+          floor_id: "floor_test",
+          is_online: false,
+        },
+      ]);
+
+      vi.spyOn(reportingClient.ReportingRequestBuilder.prototype, "execute").mockResolvedValue({
+        data: [
+          {
+            time: "2026-08-25T18:29:00Z",
+            sensor_id: "sensor_just_dropped",
+            field: "in",
+            value: 3842,
+          },
+        ],
+      } as any);
+
+      const result = await executeTrafficFlow({
+        space_id_or_name: "sensor_just_dropped",
+        time_window: "1h",
+      });
+
+      expect(result.traffic.total_entries).toBe(3842);
+      expect(result.warning).toBeUndefined();
+    });
+
+    it("does not warn on a closed historical window that predates the outage", async () => {
+      // Heartbeat (epoch seconds) after the window's stop: the sensor was
+      // alive through the whole queried range, so its zero is real data.
+      mockGraphQLTopologyAndSensors([
+        {
+          id: "sensor_died_later",
+          name: "Old Door",
+          mac_address: "aa:bb:cc:dd:ee:21",
+          mode: "traffic",
+          room_id: "room_test",
+          floor_id: "floor_test",
+          is_online: false,
+          last_heartbeat: Math.floor(new Date("2026-08-20T00:00:00Z").getTime() / 1000),
+        },
+      ]);
+
+      vi.spyOn(reportingClient.ReportingRequestBuilder.prototype, "execute").mockResolvedValue({
+        data: [],
+      } as any);
+
+      const result = await executeTrafficFlow({
+        space_id_or_name: "sensor_died_later",
+        time_window: "custom",
+        custom_start: "2026-07-01T00:00:00Z",
+        custom_stop: "2026-07-31T00:00:00Z",
+      });
+
+      expect(result.traffic.total_traffic).toBe(0);
+      expect(result.warning).toBeUndefined();
+    });
+
+    it("treats an absent is_online as offline, matching butlr_hardware_snapshot", async () => {
+      mockGraphQLTopologyAndSensors([
+        {
+          id: "sensor_no_liveness",
+          name: "Mystery Door",
+          mac_address: "aa:bb:cc:dd:ee:22",
+          mode: "traffic",
+          room_id: "room_test",
+          floor_id: "floor_test",
+          // is_online deliberately absent
+        },
+      ]);
+
+      vi.spyOn(reportingClient.ReportingRequestBuilder.prototype, "execute").mockResolvedValue({
+        data: [],
+      } as any);
+
+      const result = await executeTrafficFlow({
+        space_id_or_name: "sensor_no_liveness",
+        time_window: "1h",
+      });
+
+      expect(result.warning).toContain("offline");
     });
 
     it("warns instead of reporting a bare zero for an offline sensor", async () => {
@@ -1166,6 +1260,73 @@ describe("butlr_traffic_flow - Integration", () => {
 
       expect(result.traffic.sensor_count).toBe(1);
       expect(result.traffic.total_entries).toBe(4);
+    });
+
+    it("warns when every traffic sensor in the room is offline and the count is zero", async () => {
+      // A hive outage takes a room's sensors down together — the most
+      // confident false zero of all. The room path gets the same
+      // outage-explains-the-zero gate as the sensor path.
+      vi.mocked(apolloClient.query).mockImplementation((options: any) => {
+        const queryString = options.query.loc?.source?.body || "";
+        if (queryString.includes("GetRoomSensors")) {
+          return Promise.resolve({
+            data: {
+              room: {
+                id: "room_lobby",
+                name: "Main Lobby",
+                floorID: "floor_test",
+                sensors: [
+                  { id: "sensor_down_1", mode: "traffic" },
+                  { id: "sensor_down_2", mode: "traffic" },
+                ],
+                floor: {
+                  id: "floor_test",
+                  name: "Test Floor",
+                  building: { id: "building_test", name: "Test Building" },
+                },
+              },
+            },
+            loading: false,
+            networkStatus: 7,
+          } as any);
+        }
+        if (queryString.includes("GetFullTopology")) {
+          return Promise.resolve({ data: MOCK_TOPOLOGY, loading: false, networkStatus: 7 } as any);
+        }
+        if (queryString.includes("GetSensorsByRoomIds")) {
+          return Promise.resolve(
+            sensorsByRoomIds(options, [
+              {
+                id: "sensor_down_1",
+                mode: "traffic",
+                room_id: "room_lobby",
+                mac_address: "aa:bb:cc:dd:ee:30",
+                is_online: false,
+              },
+              {
+                id: "sensor_down_2",
+                mode: "traffic",
+                room_id: "room_lobby",
+                mac_address: "aa:bb:cc:dd:ee:31",
+                is_online: false,
+              },
+            ])
+          );
+        }
+        return Promise.reject(new Error("Unknown query"));
+      });
+
+      vi.spyOn(reportingClient.ReportingRequestBuilder.prototype, "execute").mockResolvedValue({
+        data: [],
+      } as any);
+
+      const result = await executeTrafficFlow({
+        space_id_or_name: "room_lobby",
+        time_window: "1h",
+      });
+
+      expect(result.traffic.total_traffic).toBe(0);
+      expect(result.warning).toContain("offline");
     });
 
     // The mirror rejection on the sensor path has to hold through the room

--- a/src/tools/butlr-traffic-flow.ts
+++ b/src/tools/butlr-traffic-flow.ts
@@ -266,11 +266,17 @@ export async function executeTrafficFlow(args: TrafficFlowArgs) {
       );
     }
 
-    // An uninstalled sensor reports nothing, which otherwise reads as a
+    // An offline sensor reports nothing, which otherwise reads as a
     // confident zero. That is likelier here than on the room path: the caller
     // picked one specific device rather than a room aggregating several.
-    if (sensor.installation_status === "UNINSTALLED") {
-      installationWarning = `Sensor "${sensor.name}" is marked UNINSTALLED in the platform. An uninstalled sensor reports no traffic, so a zero count is expected; any rows returned predate its removal. Check butlr_hardware_snapshot for its current status.`;
+    // `is_online` is the signal — NOT `installation_status`: that field is a
+    // provisioning-workflow checkbox set to UNINSTALLED at sensor creation and
+    // never consulted by the data pipeline; fleets routinely stream for years
+    // without it ever being flipped (customer-reported: 4 of 5 online Chicago
+    // sensors carried it; our own org has 53 online UNINSTALLED sensors and
+    // zero INSTALLED ones).
+    if (sensor.is_online === false) {
+      installationWarning = `Sensor "${sensor.name}" is currently offline. An offline sensor reports no traffic, so recent counts may read as zero; rows returned predate it going offline. Check butlr_hardware_snapshot for its health.`;
     }
 
     trafficSensors = [sensor];

--- a/src/tools/butlr-traffic-flow.ts
+++ b/src/tools/butlr-traffic-flow.ts
@@ -223,7 +223,6 @@ export async function executeTrafficFlow(args: TrafficFlowArgs) {
   let tzMetadata: TimezoneMetadata;
   let timezoneFallback = false;
   let trafficSensors: Sensor[] = [];
-  let installationWarning: string | undefined;
 
   if (isSensorQuery) {
     // One sensor by ID, not the org's whole inventory: the `sensors` root
@@ -264,19 +263,6 @@ export async function executeTrafficFlow(args: TrafficFlowArgs) {
           sensor.mode ? `a ${sensor.mode}-mode sensor` : "not a traffic-mode sensor"
         }, so it has no entry/exit counts. ${suggestion}`
       );
-    }
-
-    // An offline sensor reports nothing, which otherwise reads as a
-    // confident zero. That is likelier here than on the room path: the caller
-    // picked one specific device rather than a room aggregating several.
-    // `is_online` is the signal — NOT `installation_status`: that field is a
-    // provisioning-workflow checkbox set to UNINSTALLED at sensor creation and
-    // never consulted by the data pipeline; fleets routinely stream for years
-    // without it ever being flipped (customer-reported: 4 of 5 online Chicago
-    // sensors carried it; our own org has 53 online UNINSTALLED sensors and
-    // zero INSTALLED ones).
-    if (sensor.is_online === false) {
-      installationWarning = `Sensor "${sensor.name}" is currently offline. An offline sensor reports no traffic, so recent counts may read as zero; rows returned predate it going offline. Check butlr_hardware_snapshot for its health.`;
     }
 
     trafficSensors = [sensor];
@@ -601,8 +587,31 @@ export async function executeTrafficFlow(args: TrafficFlowArgs) {
   // Compose the response warning. Two independent conditions can raise one and
   // both matter, so they are joined rather than one silently shadowing the other.
   const warnings: string[] = [];
-  if (installationWarning) {
-    warnings.push(installationWarning);
+  // Offline warning — computed here, after the totals, because it must only
+  // qualify a zero the outage can actually explain. `is_online` is the
+  // liveness signal (NOT `installation_status`, a provisioning-workflow
+  // checkbox that nothing in the data pipeline reads and fleets routinely
+  // never flip). Truthiness matches butlr_hardware_snapshot: null/absent
+  // counts as offline. A last heartbeat at/after the window's stop means the
+  // outage began after the queried range, so the zero is real data — no
+  // warning. Sensors that dropped and reconnected inside the window can't be
+  // detected from a point-in-time heartbeat; that gap is documented, not
+  // guessed at.
+  const allSensorsOffline = trafficSensors.length > 0 && trafficSensors.every((s) => !s.is_online);
+  if (allSensorsOffline && totalTraffic === 0) {
+    const stopMs = new Date(stop).getTime();
+    const latestHeartbeatMs =
+      Math.max(0, ...trafficSensors.map((s) => s.last_heartbeat || 0)) * 1000;
+    const outageBeganAfterWindow = latestHeartbeatMs >= stopMs;
+    if (!outageBeganAfterWindow) {
+      const lastSeen =
+        latestHeartbeatMs > 0 ? ` (last seen ${new Date(latestHeartbeatMs).toISOString()})` : "";
+      warnings.push(
+        isSensorQuery
+          ? `Sensor "${displayName}" is currently offline${lastSeen}. The zero count for this window may reflect the outage rather than actual traffic. Check butlr_get_asset_details for its current status.`
+          : `All ${trafficSensors.length} traffic sensor(s) in this room are currently offline${lastSeen}. The zero count for this window may reflect the outage rather than actual traffic. Check butlr_get_asset_details for their status.`
+      );
+    }
   }
   if (usedUtcFallback) {
     // Window-aware copy. The midnight sentence is only true on the `today`


### PR DESCRIPTION
## Problem

Salesforce reports 4 of 5 online, validly-reporting sensors on Chicago Floor 57 carry the `UNINSTALLED` warning added in v0.6.0 ("an uninstalled sensor reports no traffic; any rows returned predate its removal") — while `butlr_hardware_snapshot` shows them online with valid data.

The warning trusted the wrong field. `installation_status` is a provisioning-workflow checkbox: the API sets it to `UNINSTALLED` at sensor creation (`mutations.resolvers.go:223` in butlr-api-container) and only an explicit installer-workflow mutation flips it; nothing in the data pipeline reads it. Fleets stream for years carrying it — a survey of a live org found **53 online `UNINSTALLED` sensors and zero `INSTALLED` ones**.

## Fix

The sensor-path warning now fires on `is_online: false` — the signal that actually means "reports no traffic" — with copy to match. Tests: offline sensor warns; online sensor with stale `UNINSTALLED` status returns counts with no warning. CHANGELOG + bump to 0.6.1.

## Verification

663 tests pass, typecheck/lint clean. Live against prod: an online sensor carrying stale `UNINSTALLED` status (3 movements today) returns clean; a genuinely offline sensor gets the new offline warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)